### PR TITLE
feat!: full integration rewrite v2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# APK files
+*.xapk
+*.apk

--- a/custom_components/gocube/__init__.py
+++ b/custom_components/gocube/__init__.py
@@ -2,56 +2,422 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any
+import time
 
+import voluptuous as vol
+
+from homeassistant.components.bluetooth import (
+    BluetoothCallbackMatcher,
+    BluetoothChange,
+    BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
+    async_register_callback,
+    async_track_unavailable,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
-from .gocube_ble.ble import GoCubeConnection
+from .const import DOMAIN, SIGNAL_MOVEMENT, SIGNAL_STATE_UPDATE
+from .gocube_ble.ble import GoCubeConnection, GoCubeData
+from .gocube_ble.models import KNOWN_PATTERNS
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["binary_sensor", "sensor", "light", "button", "event", "switch"]
+PLATFORMS: list[str] = [
+    "binary_sensor",
+    "button",
+    "event",
+    "image",
+    "light",
+    "sensor",
+    "switch",
+]
+
+RECONNECT_DELAY = 3.0
+MAX_RECONNECT_ATTEMPTS = 5
+STATE_UPDATE_DEBOUNCE = 0.5
+STORAGE_KEY = f"{DOMAIN}_patterns"
+STORAGE_VERSION = 1
+
+SERVICE_SAVE_PATTERN = "save_pattern"
+SERVICE_DELETE_PATTERN = "delete_pattern"
+SERVICE_LIST_PATTERNS = "list_patterns"
+ATTR_NAME = "name"
+
+SAVE_PATTERN_SCHEMA = vol.Schema({vol.Required(ATTR_NAME): str})
+DELETE_PATTERN_SCHEMA = vol.Schema({vol.Required(ATTR_NAME): str})
 
 
-class GoCubeError(HomeAssistantError):
-    """Base class for GoCube errors."""
+class PatternStore:
+    """Persistent storage for user-saved cube patterns."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the pattern store."""
+        self._store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._patterns: dict[str, str] = {}
+
+    async def async_load(self) -> None:
+        """Load patterns from storage."""
+        data = await self._store.async_load()
+        if data and isinstance(data, dict):
+            self._patterns = data.get("patterns", {})
+
+    async def async_save(self, name: str, fingerprint: str) -> None:
+        """Save a pattern."""
+        self._patterns[name] = fingerprint
+        await self._store.async_save({"patterns": self._patterns})
+
+    async def async_delete(self, name: str) -> bool:
+        """Delete a pattern. Returns True if it existed."""
+        if name in self._patterns:
+            del self._patterns[name]
+            await self._store.async_save({"patterns": self._patterns})
+            return True
+        return False
+
+    @property
+    def patterns(self) -> dict[str, str]:
+        """Return all user-saved patterns."""
+        return self._patterns
+
+    def match(self, fingerprint: str) -> str | None:
+        """Match a fingerprint against user-saved patterns."""
+        for name, fp in self._patterns.items():
+            if fp == fingerprint:
+                return name
+        return None
 
 
-class GoCubeConnectionError(GoCubeError):
-    """Raised when there is an error connecting to the GoCube."""
+class GoCubeCoordinator:
+    """Manages the GoCube BLE connection lifecycle for Home Assistant.
+
+    Implements the Yale BLE lock pattern: advertisement-triggered on-demand
+    connection for a battery-powered active-GATT device.
+    """
+
+    def __init__(self, hass: HomeAssistant, address: str) -> None:
+        """Initialize the coordinator."""
+        self.hass = hass
+        self.address = address
+        self.connection = GoCubeConnection(
+            on_state_changed=self._on_state_changed,
+            on_movement=self._on_movement,
+            on_disconnected=self._on_disconnected,
+        )
+        self._has_been_seen = False
+        self._should_auto_reconnect = True
+        self._reconnect_task: asyncio.Task | None = None
+        self._background_tasks: set[asyncio.Task] = set()
+        self._last_state_request = 0.0
+        self._pending_state_update = False
+
+    @property
+    def data(self) -> GoCubeData:
+        """Return the current cube data."""
+        return self.connection.data
+
+    @property
+    def is_connected(self) -> bool:
+        """Return whether the cube is currently connected."""
+        return self.connection.is_connected
+
+    @property
+    def has_been_seen(self) -> bool:
+        """Return whether we've ever received data from this cube."""
+        return self._has_been_seen
+
+    @property
+    def should_auto_reconnect(self) -> bool:
+        """Return whether auto-reconnect is enabled."""
+        return self._should_auto_reconnect
+
+    @should_auto_reconnect.setter
+    def should_auto_reconnect(self, value: bool) -> None:
+        """Set whether auto-reconnect is enabled."""
+        self._should_auto_reconnect = value
+
+    async def async_connect(self) -> None:
+        """Try to connect to the cube using a fresh BLEDevice from HA."""
+        device = async_ble_device_from_address(
+            self.hass, self.address, connectable=True
+        )
+        if device is None:
+            _LOGGER.debug("GoCube %s not available for connection", self.address)
+            return
+        await self.connection.connect(device)
+        # Request initial data
+        await self.connection.send_command("GetBattery")
+        await self.connection.send_command("GetState")
+        await self.connection.send_command("GetCubeType")
+        await self.connection.send_command("DisableOrientation")
+
+    async def async_disconnect(self) -> None:
+        """Disconnect and cancel all background tasks."""
+        self._cancel_reconnect()
+        for task in self._background_tasks:
+            task.cancel()
+        self._background_tasks.clear()
+        await self.connection.disconnect()
+
+    async def async_request_state_update(self) -> None:
+        """Request a state update with debouncing."""
+        now = time.monotonic()
+        if now - self._last_state_request < STATE_UPDATE_DEBOUNCE:
+            if not self._pending_state_update:
+                self._pending_state_update = True
+                self._create_task(self._async_debounced_state_update())
+            return
+        self._last_state_request = now
+        await self.connection.send_command("GetState")
+
+    def handle_advertisement(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Handle BLE advertisement — cube has woken up.
+
+        Called by HA's Bluetooth manager when the cube advertises.
+        """
+        if not self.connection.is_connected:
+            _LOGGER.debug("GoCube advertisement seen, scheduling connection")
+            self._schedule_connect()
+
+    def handle_unavailable(self, service_info: BluetoothServiceInfoBleak) -> None:
+        """Handle cube becoming unavailable — no advertisements for a while."""
+        _LOGGER.debug("GoCube %s marked unavailable by HA Bluetooth", self.address)
+        self._dispatch_state_update()
+
+    # --- Private helpers ---
+
+    def _on_state_changed(self) -> None:
+        """Handle state change from BLE notification thread."""
+        self._has_been_seen = True
+        self.hass.loop.call_soon_threadsafe(self._dispatch_state_update)
+
+    def _on_movement(self, movement: str) -> None:
+        """Handle rotation from BLE notification thread."""
+        self._has_been_seen = True
+        self.hass.loop.call_soon_threadsafe(self._dispatch_movement, movement)
+        # Request updated face state after rotation
+        self.hass.loop.call_soon_threadsafe(
+            self._create_task_from_loop, self.async_request_state_update()
+        )
+
+    def _on_disconnected(self) -> None:
+        """Handle BLE disconnection from Bleak's callback thread."""
+        self.hass.loop.call_soon_threadsafe(self._handle_disconnect_on_loop)
+
+    def _handle_disconnect_on_loop(self) -> None:
+        """Process disconnection on the event loop."""
+        self._dispatch_state_update()
+        if self._should_auto_reconnect:
+            self._schedule_reconnect()
+
+    def _dispatch_state_update(self) -> None:
+        """Send state update signal to all entities."""
+        async_dispatcher_send(
+            self.hass, f"{SIGNAL_STATE_UPDATE}_{self.address}"
+        )
+
+    def _dispatch_movement(self, movement: str) -> None:
+        """Send movement signal to event entities."""
+        async_dispatcher_send(
+            self.hass, f"{SIGNAL_MOVEMENT}_{self.address}", movement
+        )
+
+    def _schedule_connect(self) -> None:
+        """Schedule a connection attempt on the event loop."""
+        self._cancel_reconnect()
+        self._reconnect_task = self._create_task(self._async_try_connect())
+
+    def _schedule_reconnect(self) -> None:
+        """Schedule reconnection with exponential backoff."""
+        self._cancel_reconnect()
+        self._reconnect_task = self._create_task(self._async_reconnect_loop())
+
+    def _cancel_reconnect(self) -> None:
+        """Cancel any pending reconnect task."""
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            self._reconnect_task = None
+
+    async def _async_try_connect(self) -> None:
+        """Try to connect once."""
+        try:
+            await self.async_connect()
+        except Exception as err:
+            _LOGGER.debug("Connection attempt failed: %s", err)
+
+    async def _async_reconnect_loop(self) -> None:
+        """Reconnect with exponential backoff."""
+        for attempt in range(MAX_RECONNECT_ATTEMPTS):
+            if not self._should_auto_reconnect:
+                return
+            delay = RECONNECT_DELAY * (attempt + 1)
+            _LOGGER.debug(
+                "Reconnect attempt %d/%d in %.0fs",
+                attempt + 1,
+                MAX_RECONNECT_ATTEMPTS,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            if not self._should_auto_reconnect:
+                return
+            try:
+                await self.async_connect()
+                return
+            except Exception as err:
+                _LOGGER.debug("Reconnect attempt %d failed: %s", attempt + 1, err)
+
+        _LOGGER.warning(
+            "Failed to reconnect to GoCube after %d attempts",
+            MAX_RECONNECT_ATTEMPTS,
+        )
+
+    async def _async_debounced_state_update(self) -> None:
+        """Send a debounced GetState command."""
+        await asyncio.sleep(STATE_UPDATE_DEBOUNCE)
+        if self._pending_state_update:
+            self._pending_state_update = False
+            self._last_state_request = time.monotonic()
+            await self.connection.send_command("GetState")
+
+    def _create_task(self, coro) -> asyncio.Task:
+        """Create a tracked background task."""
+        task = self.hass.async_create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
+
+    def _create_task_from_loop(self, coro) -> None:
+        """Create a tracked background task (must be called from event loop)."""
+        self._create_task(coro)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up GoCube from a config entry."""
+    address = entry.data[CONF_ADDRESS]
+    coordinator = GoCubeCoordinator(hass, address)
+
+    # Try to connect now — may fail if cube is asleep, and that's OK
     try:
-        connection = GoCubeConnection()
-        await connection.connect(entry.data["address"])
-        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"connection": connection}
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-        return True
+        await coordinator.async_connect()
     except Exception as err:
-        _LOGGER.error("Failed to connect to GoCube: %s", err)
-        return False
+        _LOGGER.info("GoCube not available at startup (will connect on wake): %s", err)
+
+    # Register for BLE advertisement callbacks (cube waking up)
+    entry.async_on_unload(
+        async_register_callback(
+            hass,
+            coordinator.handle_advertisement,
+            BluetoothCallbackMatcher(address=address),
+            BluetoothChange.ADVERTISEMENT,
+        )
+    )
+
+    # Register for unavailability tracking (cube going to sleep)
+    entry.async_on_unload(
+        async_track_unavailable(
+            hass,
+            coordinator.handle_unavailable,
+            address,
+            connectable=True,
+        )
+    )
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        try:
-            connection = hass.data[DOMAIN][entry.entry_id]["connection"]
-            await connection.disconnect()
-        except Exception as err:
-            _LOGGER.error("Error disconnecting from GoCube: %s", err)
-        finally:
-            hass.data[DOMAIN].pop(entry.entry_id)
+        coordinator: GoCubeCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
+        await coordinator.async_disconnect()
     return unload_ok
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the GoCube integration."""
+    pattern_store = PatternStore(hass)
+    await pattern_store.async_load()
+    hass.data.setdefault(DOMAIN, {})["pattern_store"] = pattern_store
+
+    def _get_coordinator() -> GoCubeCoordinator | None:
+        """Get the first active coordinator."""
+        for key, val in hass.data.get(DOMAIN, {}).items():
+            if isinstance(val, GoCubeCoordinator):
+                return val
+        return None
+
+    async def handle_save_pattern(call: ServiceCall) -> None:
+        """Handle save_pattern service call."""
+        name = call.data[ATTR_NAME]
+        coordinator = _get_coordinator()
+        if coordinator is None:
+            _LOGGER.error("No GoCube connected")
+            return
+        fingerprint = coordinator.data.state_fingerprint
+        if fingerprint is None:
+            _LOGGER.error("No cube state available to save")
+            return
+        await pattern_store.async_save(name, fingerprint)
+        _LOGGER.info("Saved pattern '%s': %s", name, fingerprint)
+        # Trigger update so pattern sensor refreshes
+        coordinator._dispatch_state_update()
+
+    async def handle_delete_pattern(call: ServiceCall) -> None:
+        """Handle delete_pattern service call."""
+        name = call.data[ATTR_NAME]
+        if await pattern_store.async_delete(name):
+            _LOGGER.info("Deleted pattern '%s'", name)
+            coordinator = _get_coordinator()
+            if coordinator:
+                coordinator._dispatch_state_update()
+        else:
+            _LOGGER.warning("Pattern '%s' not found", name)
+
+    async def handle_list_patterns(call: ServiceCall) -> None:
+        """Handle list_patterns service call."""
+        lines = ["**Built-in patterns:**\n"]
+        for name, fp in KNOWN_PATTERNS.items():
+            lines.append(f"- **{name}**: `{fp}`")
+            _LOGGER.info("Built-in: %s: %s", name, fp)
+
+        if pattern_store.patterns:
+            lines.append("\n**Saved patterns:**\n")
+            for name, fp in pattern_store.patterns.items():
+                lines.append(f"- **{name}**: `{fp}`")
+                _LOGGER.info("Saved: %s: %s", name, fp)
+        else:
+            lines.append("\n*No saved patterns.*")
+
+        await hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": "GoCube Patterns",
+                "message": "\n".join(lines),
+                "notification_id": "gocube_patterns",
+            },
+        )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SAVE_PATTERN, handle_save_pattern, schema=SAVE_PATTERN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_DELETE_PATTERN, handle_delete_pattern, schema=DELETE_PATTERN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_LIST_PATTERNS, handle_list_patterns
+    )
+
     return True

--- a/custom_components/gocube/binary_sensor.py
+++ b/custom_components/gocube/binary_sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -11,12 +10,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
-from .gocube_ble.ble import GoCubeConnection
+from .const import DOMAIN, SIGNAL_STATE_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,49 +24,42 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
         key="cube_solved",
         name="Solved",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
     "blue_face": BinarySensorEntityDescription(
         key="blue_face",
-        name="Blue Face",
+        name="Face: Blue",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
     "green_face": BinarySensorEntityDescription(
         key="green_face",
-        name="Green Face",
+        name="Face: Green",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
     "white_face": BinarySensorEntityDescription(
         key="white_face",
-        name="White Face",
+        name="Face: White",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
     "yellow_face": BinarySensorEntityDescription(
         key="yellow_face",
-        name="Yellow Face",
+        name="Face: Yellow",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
     "red_face": BinarySensorEntityDescription(
         key="red_face",
-        name="Red Face",
+        name="Face: Red",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
     "orange_face": BinarySensorEntityDescription(
         key="orange_face",
-        name="Orange Face",
+        name="Face: Orange",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
 }
@@ -79,67 +71,64 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up GoCube binary sensors."""
-    connection = hass.data[DOMAIN][entry.entry_id]["connection"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        GoCubeBinarySensor(connection, entry, description)
+        GoCubeBinarySensor(coordinator, entry, description)
         for description in BINARY_SENSOR_TYPES.values()
     )
 
 
 class GoCubeBinarySensor(BinarySensorEntity):
-    """Representation of a GoCube binary sensor."""
+    """GoCube binary sensor entity."""
 
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(
-        self,
-        connection: GoCubeConnection,
-        entry: ConfigEntry,
-        description: BinarySensorEntityDescription,
-    ) -> None:
+    def __init__(self, coordinator, entry: ConfigEntry, description: BinarySensorEntityDescription) -> None:
         """Initialize the binary sensor."""
-        self.connection = connection
+        self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{entry.data['address']}_{description.key}"
+        address = entry.data[CONF_ADDRESS]
+        self._attr_unique_id = f"{address}_{description.key}"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry.data["address"])},
+            "identifiers": {(DOMAIN, address)},
             "name": entry.title,
             "model": "GoCube",
             "manufacturer": "GoCube",
         }
-        self._unsubscribe = None
+        self._address = address
 
     async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        self._unsubscribe = self.connection.register_callback(self._handle_state_change)
+        """Register dispatcher listener."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SIGNAL_STATE_UPDATE}_{self._address}",
+                self._handle_update,
+            )
+        )
 
-    def _handle_state_change(self) -> None:
-        """Handle state changes."""
+    @callback
+    def _handle_update(self) -> None:
+        """Handle state update."""
         self.async_write_ha_state()
 
     @property
-    def is_on(self) -> bool:
-        """Return if the face is solved."""
-        data = self.connection.data
-        if self.entity_description.key == "cube_solved":
-            return not data.is_solved  # Problem when not solved
-
-        # Extract color from the key (e.g., "blue_face" -> "Blue")
-        color = self.entity_description.key.split("_")[0].capitalize()
-        # Return True (problem) when face is not solved
-        return not data.face_states.get(color, False)
+    def available(self) -> bool:
+        """Return True once we've received any data from the cube."""
+        return self.coordinator.has_been_seen
 
     @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return (
-            self.connection._is_connected
-            and self.connection._client is not None
-            and self.connection._client.is_connected
-        )
+    def assumed_state(self) -> bool:
+        """Return True when disconnected (values are cached)."""
+        return not self.coordinator.is_connected
 
-    async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed from hass."""
-        if self._unsubscribe:
-            self._unsubscribe()
+    @property
+    def is_on(self) -> bool:
+        """Return True when face is NOT solved (problem sensor)."""
+        data = self.coordinator.data
+        if self.entity_description.key == "cube_solved":
+            return not data.is_solved
+
+        color = self.entity_description.key.split("_")[0].capitalize()
+        return not data.face_states.get(color, False)

--- a/custom_components/gocube/button.py
+++ b/custom_components/gocube/button.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .gocube_ble.ble import GoCubeConnection
+from .gocube_ble.models import KNOWN_PATTERNS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,24 +22,29 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up GoCube button based on a config entry."""
-    connection = hass.data[DOMAIN][entry.entry_id]["connection"]
-    async_add_entities([GoCubeRebootButton(connection, entry)])
+    """Set up GoCube buttons."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    address = entry.data[CONF_ADDRESS]
+    async_add_entities([
+        GoCubeRebootButton(coordinator, entry),
+        GoCubeListPatternsButton(coordinator, entry, address),
+    ])
 
 
 class GoCubeRebootButton(ButtonEntity):
-    """Defines a GoCube reboot button."""
+    """GoCube reboot button."""
 
     _attr_has_entity_name = True
     _attr_device_class = ButtonDeviceClass.RESTART
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, connection: GoCubeConnection, entry: ConfigEntry) -> None:
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
         """Initialize the button entity."""
-        self.connection = connection
-        self._attr_unique_id = f"{entry.data['address']}_reboot"
+        self.coordinator = coordinator
+        address = entry.data[CONF_ADDRESS]
+        self._attr_unique_id = f"{address}_reboot"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry.data["address"])},
+            "identifiers": {(DOMAIN, address)},
             "name": entry.title,
             "model": "GoCube",
             "manufacturer": "GoCube",
@@ -48,7 +53,61 @@ class GoCubeRebootButton(ButtonEntity):
     async def async_press(self) -> None:
         """Handle the button press."""
         try:
-            await self.connection.send_command("Reboot")
-            _LOGGER.debug("GoCube reboot command sent successfully")
+            await self.coordinator.connection.send_command("Reboot")
         except Exception as err:
             _LOGGER.error("Failed to reboot GoCube: %s", err)
+
+
+class GoCubeListPatternsButton(ButtonEntity):
+    """Button to list all known and saved patterns."""
+
+    _attr_has_entity_name = True
+    _attr_name = "List Patterns"
+    _attr_icon = "mdi:format-list-bulleted"
+
+    def __init__(self, coordinator, entry: ConfigEntry, address: str) -> None:
+        """Initialize the button entity."""
+        self.coordinator = coordinator
+        self._attr_unique_id = f"{address}_list_patterns"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, address)},
+            "name": entry.title,
+            "model": "GoCube",
+            "manufacturer": "GoCube",
+        }
+
+    async def async_press(self) -> None:
+        """List all patterns as a persistent notification."""
+        store = self.hass.data.get(DOMAIN, {}).get("pattern_store")
+
+        lines = ["**Built-in patterns:**\n"]
+        for name, fp in KNOWN_PATTERNS.items():
+            lines.append(f"- **{name}**: `{fp}`")
+
+        if store and store.patterns:
+            lines.append("\n**Saved patterns:**\n")
+            for name, fp in store.patterns.items():
+                lines.append(f"- **{name}**: `{fp}`")
+        else:
+            lines.append("\n*No saved patterns.*")
+
+        # Add current state
+        fp = self.coordinator.data.state_fingerprint
+        if fp:
+            matched = self.coordinator.data.matched_pattern
+            if store and not matched:
+                matched = store.match(fp)
+            label = f" ({matched})" if matched else ""
+            lines.append(f"\n**Current state{label}:** `{fp}`")
+
+        message = "\n".join(lines)
+
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": "GoCube Patterns",
+                "message": message,
+                "notification_id": "gocube_patterns",
+            },
+        )

--- a/custom_components/gocube/const.py
+++ b/custom_components/gocube/const.py
@@ -4,6 +4,6 @@ from __future__ import annotations
 
 DOMAIN = "gocube"
 
-# Default values
-DEFAULT_NAME = "GoCube"
-DEFAULT_SCAN_INTERVAL = 60
+# Dispatcher signals
+SIGNAL_STATE_UPDATE = f"{DOMAIN}_state_update"
+SIGNAL_MOVEMENT = f"{DOMAIN}_movement"

--- a/custom_components/gocube/event.py
+++ b/custom_components/gocube/event.py
@@ -3,22 +3,18 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
-from homeassistant.components.event import (
-    EventDeviceClass,
-    EventEntity,
-)
+from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
-from .gocube_ble.ble import GoCubeConnection
+from .const import DOMAIN, SIGNAL_MOVEMENT
 
 _LOGGER = logging.getLogger(__name__)
 
-# Define all possible rotation events
 ROTATION_EVENTS = [
     "blue_clockwise",
     "blue_counterclockwise",
@@ -41,40 +37,44 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up GoCube event based on a config entry."""
-    connection = hass.data[DOMAIN][entry.entry_id]["connection"]
-    async_add_entities([GoCubeRotationEvent(connection, entry)])
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([GoCubeRotationEvent(coordinator, entry)])
 
 
 class GoCubeRotationEvent(EventEntity):
-    """Defines a GoCube rotation event."""
+    """GoCube rotation event entity."""
 
     _attr_has_entity_name = True
     _attr_name = "Rotation"
     _attr_device_class = EventDeviceClass.MOTION
     _attr_event_types = ROTATION_EVENTS
 
-    def __init__(self, connection: GoCubeConnection, entry: ConfigEntry) -> None:
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
         """Initialize the event entity."""
-        self.connection = connection
-        self._attr_unique_id = f"{entry.data['address']}_rotation"
+        self.coordinator = coordinator
+        address = entry.data[CONF_ADDRESS]
+        self._attr_unique_id = f"{address}_rotation"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry.data["address"])},
+            "identifiers": {(DOMAIN, address)},
             "name": entry.title,
             "model": "GoCube",
             "manufacturer": "GoCube",
         }
+        self._address = address
 
     async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        self.connection.add_movement_callback(self._handle_movement)
+        """Register movement dispatcher listener."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SIGNAL_MOVEMENT}_{self._address}",
+                self._handle_movement,
+            )
+        )
 
+    @callback
     def _handle_movement(self, movement: str) -> None:
         """Handle movement events from the cube."""
-        # Convert "Blue Clockwise" to "blue_clockwise"
         event_type = movement.lower().replace(" ", "_")
         self._trigger_event(event_type)
         self.async_write_ha_state()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Unregister callbacks."""
-        self.connection.remove_movement_callback(self._handle_movement)

--- a/custom_components/gocube/gocube_ble/__init__.py
+++ b/custom_components/gocube/gocube_ble/__init__.py
@@ -1,7 +1,5 @@
 """GoCube Bluetooth library."""
 
-from __future__ import annotations
-
 from .connection import GoCubeConnection
 from .const import (
     COLOR_HEX_LOOKUP,
@@ -13,7 +11,7 @@ from .const import (
     RX_CHARACTERISTIC_UUID,
     TX_CHARACTERISTIC_UUID,
 )
-from .models import CubeStats, GoCubeData, Orientation
+from .models import KNOWN_PATTERNS, CubeStats, GoCubeData, Orientation
 from .parser import GoCubeDataParser
 from .renderer import render_cube_svg
 
@@ -24,6 +22,7 @@ __all__ = [
     "CubeStats",
     "FACE_ROTATION_MAP",
     "GoCubeConnection",
+    "KNOWN_PATTERNS",
     "GoCubeData",
     "GoCubeDataParser",
     "ISOMETRIC_FACES",

--- a/custom_components/gocube/gocube_ble/connection.py
+++ b/custom_components/gocube/gocube_ble/connection.py
@@ -1,392 +1,193 @@
-"""Connection management for GoCube."""
+"""Thin BLE connection wrapper for GoCube.
+
+This module handles only the Bleak connection lifecycle: connect, disconnect,
+send commands, and receive notifications. All reconnect policy, debouncing,
+and HA-specific logic belongs in the integration layer.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import time
-from typing import Any, Callable, Optional, Set
+from typing import Any, Callable
 
-from bleak import BleakClient, BleakScanner
+from bleak import BleakClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
 from .const import (
     CONFIGURATION_COMMANDS,
     FACE_ROTATION_MAP,
-    MSG_TYPE_BATTERY,
-    MSG_TYPE_ROTATION,
-    MSG_TYPE_STATE,
     RX_CHARACTERISTIC_UUID,
     TX_CHARACTERISTIC_UUID,
-    PRIMARY_SERVICE_UUID,
 )
+from .models import GoCubeData
 from .parser import GoCubeDataParser
 
 _LOGGER = logging.getLogger(__name__)
 
-MAX_RETRIES = 3
-RETRY_DELAY = 2.0  # seconds
-CONNECT_TIMEOUT = 20.0  # seconds
-DISCONNECT_TIMEOUT = 10.0  # seconds
-SCAN_TIMEOUT = 5.0  # seconds
-CLEANUP_DELAY = 1.0  # seconds
+CONNECT_TIMEOUT = 20.0
 
 
 class GoCubeConnection:
-    """Manager for GoCube Bluetooth connection."""
+    """Thin BLE connection wrapper for GoCube.
 
-    def __init__(self) -> None:
-        """Initialize the connection manager."""
-        self._client: Optional[BleakClient] = None
-        self._characteristic: Optional[str] = None
-        self._data_parser = GoCubeDataParser()
+    Manages a single BleakClient connection. Callbacks are invoked from
+    Bleak's notification thread — callers are responsible for thread safety.
+    """
+
+    def __init__(
+        self,
+        on_state_changed: Callable[[], None] | None = None,
+        on_movement: Callable[[str], None] | None = None,
+        on_disconnected: Callable[[], None] | None = None,
+    ) -> None:
+        """Initialize the connection.
+
+        Args:
+            on_state_changed: Called when cube data changes (battery, state, etc).
+                              Called from Bleak's notification thread.
+            on_movement: Called with rotation description on each face rotation.
+                         Called from Bleak's notification thread.
+            on_disconnected: Called when the BLE connection drops.
+                             Called from Bleak's callback thread.
+        """
+        self._client: BleakClient | None = None
+        self._write_char: str | None = None
+        self._parser = GoCubeDataParser()
         self._is_connected = False
-        self._device: Optional[BLEDevice] = None
-        self._response_event: Optional[asyncio.Event] = None
-        self._state_callbacks: Set[Callable[[], None]] = set()
-        self._movement_callbacks: Set[Callable[[str], None]] = set()
-        self._connection_lock = asyncio.Lock()
-        self._last_state_update = 0
-        self._state_update_interval = 0.5  # seconds
-        self._pending_state_update = False
-        self._should_auto_reconnect = True  # New property to control auto-reconnection
+        self._on_state_changed = on_state_changed
+        self._on_movement = on_movement
+        self._on_disconnected = on_disconnected
 
     @property
-    def should_auto_reconnect(self) -> bool:
-        """Return whether the connection should auto-reconnect."""
-        return self._should_auto_reconnect
-
-    @should_auto_reconnect.setter
-    def should_auto_reconnect(self, value: bool) -> None:
-        """Set whether the connection should auto-reconnect."""
-        self._should_auto_reconnect = value
+    def is_connected(self) -> bool:
+        """Return whether the BLE connection is active."""
+        return self._is_connected
 
     @property
     def data(self) -> GoCubeData:
-        """Get the current data from the parser."""
-        return self._data_parser.data
-
-    async def __aenter__(self) -> "GoCubeConnection":
-        """Set up the async context manager."""
-        return self
-
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Clean up the async context manager."""
-        await self.disconnect()
-
-    async def _find_device(self, address: str) -> Optional[BLEDevice]:
-        """Find the GoCube device by scanning.
-
-        Args:
-            address: The MAC address of the device
-
-        Returns:
-            Optional[BLEDevice]: The found device or None if not found
-        """
-        _LOGGER.info("Scanning for GoCube device %s", address)
-        scanner = BleakScanner()
-        try:
-            devices = await scanner.discover(timeout=SCAN_TIMEOUT)
-            for device in devices:
-                if device.address == address:
-                    _LOGGER.info(
-                        "Found GoCube device: %s", device.name or device.address
-                    )
-                    return device
-            _LOGGER.warning("GoCube device %s not found during scan", address)
-            return None
-        except Exception as err:
-            _LOGGER.error("Error scanning for device: %s", err)
-            return None
-
-    async def _cleanup_connection(self) -> None:
-        """Clean up any existing connection."""
-        if self._client is not None:
-            try:
-                # Stop notifications before disconnecting
-                try:
-                    await self._client.stop_notify(TX_CHARACTERISTIC_UUID)
-                except Exception:
-                    pass
-                await self._client.disconnect()
-                _LOGGER.info("Cleaned up existing connection")
-            except Exception as err:
-                _LOGGER.error("Error during connection cleanup: %s", err)
-            finally:
-                self._client = None
-                self._characteristic = None
-                self._is_connected = False
-                self._device = None
-                # Reset parser data
-                self._data_parser = GoCubeDataParser()
-                # Notify callbacks of disconnection
-                for callback in self._state_callbacks:
-                    callback()
-                await asyncio.sleep(CLEANUP_DELAY)  # Wait for cleanup to complete
+        """Return the current parsed data."""
+        return self._parser.data
 
     async def connect(self, device: BLEDevice) -> None:
-        """Connect to the GoCube with retry logic."""
-        async with self._connection_lock:
-            retry_count = 0
-            while retry_count < MAX_RETRIES:
-                try:
-                    # Clean up any existing connection first
-                    await self._cleanup_connection()
+        """Connect to the GoCube.
 
-                    self._device = device
-                    self._client = BleakClient(device, timeout=CONNECT_TIMEOUT)
+        Args:
+            device: A fresh BLEDevice from HA's Bluetooth manager.
 
-                    _LOGGER.info(
-                        "Attempting to connect to GoCube (attempt %d/%d)...",
-                        retry_count + 1,
-                        MAX_RETRIES,
-                    )
+        Raises:
+            BleakError: If connection fails.
+        """
+        # Clean up any existing connection
+        await self._disconnect_client()
 
-                    await self._client.connect()
-                    _LOGGER.debug("Connected to GoCube")
+        self._client = BleakClient(
+            device,
+            timeout=CONNECT_TIMEOUT,
+            disconnected_callback=self._handle_disconnect,
+        )
 
-                    # Find the characteristics
-                    notify_char = None
-                    write_char = None
+        _LOGGER.info("Connecting to GoCube %s...", device.address)
+        await self._client.connect()
 
-                    for service in self._client.services:
-                        for char in service.characteristics:
-                            if (
-                                char.uuid == TX_CHARACTERISTIC_UUID
-                            ):  # Notification characteristic
-                                notify_char = char.uuid
-                            elif (
-                                char.uuid == RX_CHARACTERISTIC_UUID
-                            ):  # Write characteristic
-                                write_char = char.uuid
+        # Find characteristics
+        notify_char = None
+        write_char = None
+        for service in self._client.services:
+            for char in service.characteristics:
+                if char.uuid == TX_CHARACTERISTIC_UUID:
+                    notify_char = char.uuid
+                elif char.uuid == RX_CHARACTERISTIC_UUID:
+                    write_char = char.uuid
 
-                    if not notify_char or not write_char:
-                        raise BleakError("Required characteristics not found")
+        if not notify_char or not write_char:
+            await self._disconnect_client()
+            raise BleakError("Required UART characteristics not found")
 
-                    # Set up notification handler
-                    await self._client.start_notify(
-                        notify_char,
-                        self._notification_handler,
-                    )
-
-                    self._characteristic = (
-                        write_char  # Store write characteristic for sending commands
-                    )
-                    self._is_connected = True
-
-                    # Disable orientation updates
-                    await self.send_command("DisableOrientation")
-                    _LOGGER.debug("Disabled orientation updates")
-
-                    # Notify callbacks of successful connection
-                    for callback in self._state_callbacks:
-                        callback()
-
-                    return  # Successfully connected
-
-                except Exception as err:
-                    _LOGGER.error(
-                        "Failed to connect to GoCube (attempt %d/%d): %s",
-                        retry_count + 1,
-                        MAX_RETRIES,
-                        err,
-                    )
-                    await self._cleanup_connection()
-                    retry_count += 1
-                    if retry_count < MAX_RETRIES:
-                        await asyncio.sleep(RETRY_DELAY)
-                    else:
-                        raise
-
-    def _handle_disconnect(self, client: BleakClient) -> None:
-        """Handle disconnection event."""
-        self._is_connected = False
-        self._notify_state_change()
-        
-        if self._should_auto_reconnect and self._device:
-            _LOGGER.debug("Device disconnected, scheduling reconnection")
-            asyncio.create_task(self._auto_reconnect())
-        else:
-            _LOGGER.debug("Device disconnected, auto-reconnect disabled")
-
-    async def _auto_reconnect(self) -> None:
-        """Attempt to reconnect to the device."""
-        if not self._should_auto_reconnect or not self._device:
-            return
-
-        for attempt in range(MAX_RETRIES):
-            try:
-                await asyncio.sleep(RETRY_DELAY * (attempt + 1))
-                if not self._should_auto_reconnect:
-                    _LOGGER.debug("Auto-reconnect cancelled")
-                    return
-                _LOGGER.debug("Attempting to reconnect (attempt %d/%d)", attempt + 1, MAX_RETRIES)
-                await self.connect(self._device)
-                return
-            except Exception as err:
-                _LOGGER.debug("Reconnection attempt failed: %s", err)
-
-        _LOGGER.warning("Failed to reconnect after %d attempts", MAX_RETRIES)
+        await self._client.start_notify(notify_char, self._notification_handler)
+        self._write_char = write_char
+        self._is_connected = True
+        _LOGGER.info("Connected to GoCube %s", device.address)
 
     async def disconnect(self) -> None:
-        """Disconnect from the device."""
-        self._should_auto_reconnect = False  # Disable auto-reconnect before disconnecting
-        if self._client:
-            await self._client.disconnect()
-        await self._cleanup_connection()
-
-    async def enable_notifications(self) -> None:
-        """Enable notifications from the GoCube."""
-        try:
-            await self._client.start_notify(
-                TX_CHARACTERISTIC_UUID,
-                self._notification_handler,
-            )
-            _LOGGER.info("Notifications enabled")
-        except BleakError as err:
-            _LOGGER.error("Failed to enable notifications: %s", err)
-            raise
-
-    def register_callback(self, callback: Callable[[], None]) -> Callable[[], None]:
-        """Register a callback for state changes."""
-
-        def unsubscribe() -> None:
-            """Unsubscribe from state changes."""
-            if callback in self._state_callbacks:
-                self._state_callbacks.remove(callback)
-
-        self._state_callbacks.add(callback)
-        return unsubscribe
-
-    def _notify_state_change(self) -> None:
-        """Notify all state callbacks."""
-        _LOGGER.debug("Notifying %d state callbacks", len(self._state_callbacks))
-        for callback in self._state_callbacks:
-            try:
-                callback()
-            except Exception as err:
-                _LOGGER.error("Error in state callback: %s", err)
-
-    def add_movement_callback(self, callback: Callable[[str], None]) -> None:
-        """Add a callback for movement events."""
-        self._movement_callbacks.add(callback)
-
-    def remove_movement_callback(self, callback: Callable[[str], None]) -> None:
-        """Remove a callback for movement events."""
-        self._movement_callbacks.discard(callback)
+        """Disconnect from the GoCube."""
+        await self._disconnect_client()
 
     async def send_command(self, command_name: str) -> None:
-        """Send a command to the GoCube."""
-        if not self._is_connected or self._characteristic is None:
-            _LOGGER.debug("Cannot send command '%s': device is disconnected", command_name)
-            return  # Silently return instead of raising an error
+        """Send a named command to the GoCube.
 
-        if not self._client or not self._client.is_connected:
-            _LOGGER.debug("Cannot send command '%s': connection lost", command_name)
-            return  # Silently return instead of raising an error
+        Silently returns if not connected.
+
+        Raises:
+            ValueError: If command_name is not a known command.
+        """
+        if not self._is_connected or not self._client or not self._write_char:
+            _LOGGER.debug("Cannot send '%s': not connected", command_name)
+            return
 
         command_data = CONFIGURATION_COMMANDS.get(command_name)
         if command_data is None:
             raise ValueError(f"Unknown command: {command_name}")
 
         try:
-            # Debounce GetState commands
-            if command_name == "GetState":
-                current_time = time.time()
-                if current_time - self._last_state_update < self._state_update_interval:
-                    if not self._pending_state_update:
-                        self._pending_state_update = True
-                        asyncio.create_task(self._send_debounced_state_update())
-                    return
-                self._last_state_update = current_time
-
-            await self._client.write_gatt_char(self._characteristic, command_data)
+            await self._client.write_gatt_char(self._write_char, command_data)
             _LOGGER.debug("Sent command: %s", command_name)
-        except Exception as err:
-            _LOGGER.debug("Failed to send command %s: %s", command_name, err)  # Changed to debug level
-            # Don't raise the error, just log it
+        except BleakError as err:
+            _LOGGER.debug("Failed to send %s: %s", command_name, err)
 
-    async def _send_debounced_state_update(self) -> None:
-        """Send a debounced GetState command."""
-        await asyncio.sleep(self._state_update_interval)
-        if self._pending_state_update:
-            try:
-                await self.send_command("GetState")
-            finally:
-                self._pending_state_update = False
+    async def send_raw(self, data: bytearray) -> None:
+        """Send raw bytes to the GoCube.
 
-    def _notification_handler(self, sender: int, data: bytearray) -> None:
-        """Handle notifications from the GoCube."""
+        Silently returns if not connected.
+        """
+        if not self._is_connected or not self._client or not self._write_char:
+            _LOGGER.debug("Cannot send raw data: not connected")
+            return
+
         try:
-            if len(data) < 3:
-                return
+            await self._client.write_gatt_char(self._write_char, data)
+            _LOGGER.debug("Sent raw: %s", data.hex())
+        except BleakError as err:
+            _LOGGER.debug("Failed to send raw data: %s", err)
 
-            message_type = data[2]
-            if message_type == MSG_TYPE_ROTATION:  # Rotation
-                face_rotation = data[3]
-                face_rotation_desc = FACE_ROTATION_MAP.get(face_rotation, "Unknown")
-                _LOGGER.debug("Rotation: %s", face_rotation_desc)
-                for callback in self._movement_callbacks:
-                    callback(face_rotation_desc)
-                # Get state after rotation
-                asyncio.create_task(self.send_command("GetState"))
-            elif message_type == MSG_TYPE_STATE:  # State
-                self._data_parser.parse_state_message(data)
-                _LOGGER.debug("State updated, notifying callbacks")
-                self._notify_state_change()
-            elif message_type == MSG_TYPE_BATTERY:  # Battery
-                self._data_parser.parse_battery_message(data)
-                _LOGGER.debug("Battery updated, notifying callbacks")
-                self._notify_state_change()
-            else:
-                _LOGGER.debug("Unknown message type: %02x", message_type)
+    async def _disconnect_client(self) -> None:
+        """Disconnect and clean up the BleakClient."""
+        self._is_connected = False
+        if self._client is not None:
+            try:
+                if self._client.is_connected:
+                    try:
+                        await self._client.stop_notify(TX_CHARACTERISTIC_UUID)
+                    except Exception:
+                        pass
+                    await self._client.disconnect()
+            except Exception as err:
+                _LOGGER.debug("Error during disconnect: %s", err)
+            finally:
+                self._client = None
+                self._write_char = None
+
+    def _handle_disconnect(self, client: BleakClient) -> None:
+        """Handle BLE disconnection callback from Bleak."""
+        _LOGGER.info("GoCube disconnected")
+        self._is_connected = False
+        if self._on_disconnected:
+            self._on_disconnected()
+
+    def _notification_handler(self, sender: Any, data: bytearray) -> None:
+        """Handle BLE notifications from the GoCube.
+
+        Called from Bleak's notification thread.
+        """
+        try:
+            handled = self._parser.parse_message(data)
+
+            if "rotation" in handled:
+                if self._on_movement and self._parser.data.last_move:
+                    self._on_movement(self._parser.data.last_move)
+
+            if any(t in handled for t in ("state", "battery", "orientation", "stats", "cube_type")):
+                if self._on_state_changed:
+                    self._on_state_changed()
         except Exception as err:
             _LOGGER.error("Error handling notification: %s", err)
-
-    async def get_battery_level(self) -> Optional[int]:
-        """Get the battery level from the GoCube."""
-        try:
-            # Send GetBattery command
-            await self.send_command("GetBattery")
-
-            # Wait for response
-            start_time = time.time()
-            while time.time() - start_time < 1.0:
-                if self._data_parser.data.battery_level is not None:
-                    return self._data_parser.data.battery_level
-                await asyncio.sleep(0.1)
-
-            return None
-        except Exception as err:
-            _LOGGER.error("Failed to get battery level: %s", err)
-            return None
-
-    # LED Control Methods
-    async def led_flash(self) -> None:
-        """Flash the backlight three times."""
-        await self.send_command("LedFlash")
-
-    async def led_toggle_animation(self) -> None:
-        """Enable or disable animated backlight."""
-        await self.send_command("LedToggleAnimation")
-
-    async def led_flash_slow(self) -> None:
-        """Slowly flash the backlight three times."""
-        await self.send_command("LedFlashSlow")
-
-    async def led_toggle(self) -> None:
-        """Toggle backlight."""
-        await self.send_command("LedToggle")
-
-    async def enable_auto_reconnect(self) -> None:
-        """Enable auto-reconnect feature."""
-        was_disabled = not self._should_auto_reconnect
-        self._should_auto_reconnect = True
-        
-        # If auto-reconnect was disabled and we're not connected, try to reconnect immediately
-        if was_disabled and not self._is_connected and self._device:
-            _LOGGER.debug("Auto-reconnect enabled, attempting immediate reconnection")
-            await self._auto_reconnect()
-        else:
-            _LOGGER.debug("Auto-reconnect enabled, device is already connected or no device info available")

--- a/custom_components/gocube/gocube_ble/const.py
+++ b/custom_components/gocube/gocube_ble/const.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-# Bluetooth UUIDs
+# Bluetooth UUIDs (Nordic UART Service)
 PRIMARY_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
 RX_CHARACTERISTIC_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
 TX_CHARACTERISTIC_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
 
-# Message constants
+# Message framing
 MSG_PREFIX = 0x2A
 MSG_SUFFIX = bytearray([0x0D, 0x0A])  # CR, LF
 
@@ -34,6 +34,14 @@ CONFIGURATION_COMMANDS = {
     "LedToggleAnimation": bytearray([0x42]),
     "LedFlashSlow": bytearray([0x43]),
     "LedToggle": bytearray([0x44]),
+    # LED Brightness Presets (0x45=brightest → 0x4B=off)
+    "LedBrightness6": bytearray([0x45]),
+    "LedBrightness5": bytearray([0x46]),
+    "LedBrightness4": bytearray([0x47]),
+    "LedBrightness3": bytearray([0x48]),
+    "LedBrightness2": bytearray([0x49]),
+    "LedBrightness1": bytearray([0x4A]),
+    "LedBrightnessOff": bytearray([0x4B]),
 }
 
 # Face rotation mapping
@@ -52,7 +60,7 @@ FACE_ROTATION_MAP = {
     0x0B: "Orange Counterclockwise",
 }
 
-# Color mapping
+# Color index to name mapping
 COLOR_HEX_LOOKUP = {
     0x00: "Blue",
     0x01: "Green",
@@ -61,3 +69,16 @@ COLOR_HEX_LOOKUP = {
     0x04: "Red",
     0x05: "Orange",
 }
+
+# Color name to RGB hex for rendering
+COLOR_RGB = {
+    "Blue": "#0051BA",
+    "Green": "#009E60",
+    "White": "#FFFFFF",
+    "Yellow": "#FFD500",
+    "Red": "#C41E3A",
+    "Orange": "#FF5800",
+}
+
+# Standard face ordering for isometric rendering (top, right, left)
+ISOMETRIC_FACES = ("White", "Blue", "Red")

--- a/custom_components/gocube/gocube_ble/models.py
+++ b/custom_components/gocube/gocube_ble/models.py
@@ -2,8 +2,44 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Orientation:
+    """Quaternion orientation data from the cube's IMU."""
+
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+    w: float = 1.0
+
+
+@dataclass
+class CubeStats:
+    """Session statistics from the cube."""
+
+    solve_count: int = 0
+    total_solve_time_ms: int = 0
+
+
+# Known cube patterns: name → fingerprint
+KNOWN_PATTERNS: dict[str, str] = {
+    "Solved": "WWWWWWWWWYYYYYYYYYBBBBBBBBBGGGGGGGGGRRRRRRRRROOOOOOOOO",
+    "Checkerboard": "WYWYWYWYWYWYWYWYWYBGBGBGBGBGBGBGBGBGRORORORORORORORORO",
+}
+
+_COLOR_ABBREV = {
+    "Blue": "B",
+    "Green": "G",
+    "White": "W",
+    "Yellow": "Y",
+    "Red": "R",
+    "Orange": "O",
+}
+
+# Canonical face order for fingerprint
+_FACE_ORDER = ("White", "Yellow", "Blue", "Green", "Red", "Orange")
 
 
 @dataclass
@@ -12,12 +48,40 @@ class GoCubeData:
 
     battery_level: int | None = None
     is_solved: bool = False
-    face_states: Dict[str, bool] = None
-    last_update: float | None = None
-    last_move: str | None = None
+    face_states: dict[str, bool] = field(default_factory=dict)
+    face_colors: dict[str, list[str]] = field(default_factory=dict)
+    orientation: Orientation | None = None
+    stats: CubeStats | None = None
     cube_type: str | None = None
+    last_move: str | None = None
 
-    def __post_init__(self) -> None:
-        """Initialize face states dictionary."""
-        if self.face_states is None:
-            self.face_states = {}
+    @property
+    def state_fingerprint(self) -> str | None:
+        """Return a compact string representing the full cube state.
+
+        Format: 54 single-letter color codes (6 faces × 9 stickers),
+        faces in canonical order (W/Y/B/G/R/O), stickers in row-major.
+        Example solved cube: "WWWWWWWWWYYYYYYYYYBBBBBBBBBGGGGGGGGGRRRRRRRRROOOOOOOOO"
+
+        Returns None if face data is not yet available.
+        """
+        if len(self.face_colors) < 6:
+            return None
+        parts = []
+        for face in _FACE_ORDER:
+            stickers = self.face_colors.get(face)
+            if not stickers or len(stickers) != 9:
+                return None
+            parts.extend(_COLOR_ABBREV.get(c, "?") for c in stickers)
+        return "".join(parts)
+
+    @property
+    def matched_pattern(self) -> str | None:
+        """Return the name of a known pattern if the current state matches one."""
+        fp = self.state_fingerprint
+        if fp is None:
+            return None
+        for name, pattern in KNOWN_PATTERNS.items():
+            if fp == pattern:
+                return name
+        return None

--- a/custom_components/gocube/gocube_ble/parser.py
+++ b/custom_components/gocube/gocube_ble/parser.py
@@ -1,135 +1,265 @@
-"""Parser for GoCube data."""
+"""Parser for GoCube BLE protocol messages."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Set
+import struct
 
 from .const import (
     COLOR_HEX_LOOKUP,
+    FACE_ROTATION_MAP,
+    MSG_PREFIX,
+    MSG_SUFFIX,
     MSG_TYPE_BATTERY,
-    MSG_TYPE_STATE,
+    MSG_TYPE_CUBE_TYPE,
     MSG_TYPE_ORIENTATION,
     MSG_TYPE_ROTATION,
+    MSG_TYPE_STATE,
+    MSG_TYPE_STATS,
 )
-from .models import GoCubeData
+from .models import CubeStats, GoCubeData, Orientation
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class GoCubeDataParser:
-    """Parser for GoCube data."""
+    """Parser for GoCube BLE protocol messages.
+
+    This parser is stateful — it accumulates data across messages
+    and persists last-known values across connection cycles.
+    """
 
     def __init__(self) -> None:
         """Initialize the parser."""
         self.data = GoCubeData()
-        self._state_callbacks: Set[Callable[[], None]] = set()
-        self._movement_callbacks: Set[Callable[[str], None]] = set()
 
-    def parse_state_message(self, data: bytearray) -> None:
-        """Parse state message."""
-        if len(data) >= 60:
-            state_data = data[3:]  # Start parsing from offset 3
-            face_data = [state_data[i : i + 9] for i in range(0, 54, 9)]
+    def parse_message(self, raw: bytearray) -> list[str]:
+        """Parse a raw BLE notification and return list of message types handled.
 
-            # Update each face's solved state
-            for i, colors in enumerate(face_data):
-                face_name = list(COLOR_HEX_LOOKUP.values())[i]
-                face_colors = [COLOR_HEX_LOOKUP.get(byte) for byte in colors[1:]]
-                self.data.face_states[face_name] = self._is_face_solved(face_colors)
+        Returns a list of message type strings that were successfully parsed,
+        e.g. ["rotation", "state"] or ["battery"].
+        """
+        handled: list[str] = []
+
+        if len(raw) < 3:
+            _LOGGER.debug("Message too short (%d bytes): %s", len(raw), raw.hex())
+            return handled
+
+        # Validate frame prefix if present
+        if raw[0] == MSG_PREFIX:
+            data = raw
+        else:
+            _LOGGER.debug("Message missing prefix (0x%02x): %s", raw[0], raw.hex())
+            data = raw
+
+        msg_type = data[2]
+
+        if msg_type == MSG_TYPE_ROTATION:
+            rotations = self._parse_rotation_message(data)
+            if rotations:
+                handled.append("rotation")
+        elif msg_type == MSG_TYPE_STATE:
+            if self._parse_state_message(data):
+                handled.append("state")
+        elif msg_type == MSG_TYPE_ORIENTATION:
+            if self._parse_orientation_message(data):
+                handled.append("orientation")
+        elif msg_type == MSG_TYPE_BATTERY:
+            if self._parse_battery_message(data):
+                handled.append("battery")
+        elif msg_type == MSG_TYPE_STATS:
+            if self._parse_stats_message(data):
+                handled.append("stats")
+        elif msg_type == MSG_TYPE_CUBE_TYPE:
+            if self._parse_cube_type_message(data):
+                handled.append("cube_type")
+        else:
+            _LOGGER.debug("Unknown message type: 0x%02x data=%s", msg_type, data.hex())
+
+        return handled
+
+    def _parse_rotation_message(self, data: bytearray) -> list[str]:
+        """Parse rotation message.
+
+        Format: [prefix, len, 0x01, face_byte, ...trailing bytes]
+        The face rotation byte is at index 3. Remaining bytes are
+        counters/checksums.
+
+        Returns list of rotation descriptions.
+        """
+        rotations: list[str] = []
+        if len(data) < 4:
+            return rotations
+
+        rotation_byte = data[3]
+        desc = FACE_ROTATION_MAP.get(rotation_byte)
+        if desc:
+            rotations.append(desc)
+            self.data.last_move = desc
+            _LOGGER.debug("Rotation: %s (0x%02x)", desc, rotation_byte)
+        else:
+            _LOGGER.debug(
+                "Unknown rotation byte: 0x%02x data=%s", rotation_byte, data.hex()
+            )
+
+        return rotations
+
+    def _parse_state_message(self, data: bytearray) -> bool:
+        """Parse state message with per-sticker color data.
+
+        Each face block is 9 bytes: [center_color, s0, s1, s2, s3, s4, s5, s6, s7]
+        The center byte identifies which face this block belongs to.
+        Sticker order (looking at face straight-on):
+          s0 s1 s2
+          s3  C s4
+          s5 s6 s7
+        """
+        if len(data) < 57:  # prefix + len + type + 54 color bytes
+            _LOGGER.debug("State message too short: %d bytes", len(data))
+            return False
+
+        state_data = data[3:]
+
+        for i in range(6):
+            offset = i * 9
+            if offset + 9 > len(state_data):
+                break
+
+            face_bytes = state_data[offset : offset + 9]
+
+            # Use byte 0 (center color) to identify which face this is
+            center_byte = face_bytes[0]
+            face_name = COLOR_HEX_LOOKUP.get(center_byte)
+            if face_name is None:
                 _LOGGER.debug(
-                    "%s Face: %s",
-                    face_name,
-                    "Solved" if self.data.face_states[face_name] else "Not Solved",
+                    "Unknown center color 0x%02x in face block %d: %s",
+                    center_byte, i, face_bytes.hex(),
                 )
+                continue
 
-            # Check if all faces are solved
-            self.data.is_solved = all(self.data.face_states.values())
-            if self.data.is_solved:
-                _LOGGER.debug("🎉 Cube Solved! 🎉")
-            else:
-                _LOGGER.debug("Cube Not Solved Yet")
+            center_color = face_name
+            surround_colors = [
+                COLOR_HEX_LOOKUP.get(b, "Unknown") for b in face_bytes[1:]
+            ]
 
-            self._notify_state_change()
+            # Surrounding stickers are in clockwise order:
+            # s0=UL, s1=U, s2=UR, s3=R, s4=DR, s5=D, s6=DL, s7=L
+            # Reconstruct 3x3 grid in row-major order:
+            sticker_grid = [
+                surround_colors[0],  # UL
+                surround_colors[1],  # U
+                surround_colors[2],  # UR
+                surround_colors[7],  # L
+                center_color,        # Center
+                surround_colors[3],  # R
+                surround_colors[6],  # DL
+                surround_colors[5],  # D
+                surround_colors[4],  # DR
+            ]
 
-    def parse_battery_message(self, data: bytearray) -> None:
-        """Parse battery message."""
-        if len(data) >= 5:
-            battery_level = data[3]
-            checksum = sum(data[:4]) % 0x100
-            if checksum == data[4]:
-                self.data.battery_level = battery_level
-                _LOGGER.debug("Updated battery level: %d%%", self.data.battery_level)
-            else:
-                _LOGGER.debug("Invalid battery status checksum")
+            self.data.face_colors[face_name] = sticker_grid
 
-    def parse_orientation_message(self, data: bytearray) -> None:
-        """Parse orientation message."""
-        if len(data) >= 5:
-            # Orientation messages are used to track the cube's physical orientation
-            # We don't need to store this data, but we should acknowledge receipt
-            _LOGGER.debug("Received orientation update")
+            # Check if face is solved (all stickers same color)
+            is_solved = all(c == sticker_grid[0] for c in sticker_grid)
+            self.data.face_states[face_name] = is_solved
 
-    def _is_face_solved(self, face_colors: list[str]) -> bool:
-        """Check if a face is solved (all colors match the center)."""
-        return all(color == face_colors[0] for color in face_colors)
+            _LOGGER.debug(
+                "%s face (block %d): %s raw=%s",
+                face_name,
+                i,
+                "Solved" if is_solved else "Not solved",
+                face_bytes.hex(),
+            )
 
-    def _notify_state_change(self) -> None:
-        """Notify all state callbacks."""
-        for callback in self._state_callbacks:
-            try:
-                callback()
-            except Exception as err:
-                _LOGGER.error("Error in state callback: %s", err)
+        self.data.is_solved = all(self.data.face_states.values())
+        if self.data.is_solved:
+            _LOGGER.debug("Cube solved!")
 
-    def update(self, data: bytes) -> None:
-        """Update the data."""
+        return True
+
+    def _parse_battery_message(self, data: bytearray) -> bool:
+        """Parse battery message with checksum validation."""
+        if len(data) < 5:
+            return False
+
+        battery_level = data[3]
+        checksum = sum(data[:4]) % 0x100
+        if checksum != data[4]:
+            _LOGGER.debug("Invalid battery checksum")
+            return False
+
+        self.data.battery_level = battery_level
+        _LOGGER.debug("Battery level: %d%%", battery_level)
+        return True
+
+    def _parse_orientation_message(self, data: bytearray) -> bool:
+        """Parse orientation quaternion message.
+
+        The GoCube sends orientation as 4 signed int16 values (little-endian)
+        representing the quaternion (x, y, z, w) scaled by 16384.
+        """
+        if len(data) < 11:  # prefix + len + type + 8 bytes (4 x int16)
+            _LOGGER.debug("Orientation message too short: %d bytes", len(data))
+            return False
+
         try:
-            # Parse the data
-            if len(data) < 5:  # Minimum length for a valid message
-                _LOGGER.debug("Message too short: %s", data.hex())
-                return
+            # Parse 4 signed int16 values from bytes 3-10
+            x_raw, y_raw, z_raw, w_raw = struct.unpack_from("<hhhh", data, 3)
+            scale = 16384.0
+            self.data.orientation = Orientation(
+                x=x_raw / scale,
+                y=y_raw / scale,
+                z=z_raw / scale,
+                w=w_raw / scale,
+            )
+            _LOGGER.debug(
+                "Orientation: x=%.3f y=%.3f z=%.3f w=%.3f",
+                self.data.orientation.x,
+                self.data.orientation.y,
+                self.data.orientation.z,
+                self.data.orientation.w,
+            )
+            return True
+        except struct.error as err:
+            _LOGGER.debug("Failed to parse orientation: %s", err)
+            return False
 
-            # Get message type
-            msg_type = data[2] if len(data) > 2 else None
-            _LOGGER.debug("Message type: %02x", msg_type)
+    def _parse_stats_message(self, data: bytearray) -> bool:
+        """Parse session statistics message."""
+        if len(data) < 7:
+            _LOGGER.debug("Stats message too short: %d bytes", len(data))
+            return False
 
-            # Handle different message types
-            if msg_type == MSG_TYPE_BATTERY:  # Battery
-                self.parse_battery_message(data)
-            elif msg_type == MSG_TYPE_STATE:  # State
-                self.parse_state_message(data)
-            elif msg_type == MSG_TYPE_ORIENTATION:  # Orientation
-                self.parse_orientation_message(data)
-            elif msg_type == MSG_TYPE_ROTATION:  # Rotation
-                # Rotation messages are handled by the connection class
-                pass
-            else:
-                _LOGGER.debug("Unhandled message type: %02x", msg_type)
-        except Exception as err:
-            _LOGGER.error("Error parsing message: %s", err)
-            _LOGGER.debug("Raw data: %s", data.hex())
+        try:
+            solve_count = data[3]
+            # Total solve time as uint16 (milliseconds)
+            total_time = struct.unpack_from("<H", data, 4)[0]
+            self.data.stats = CubeStats(
+                solve_count=solve_count,
+                total_solve_time_ms=total_time,
+            )
+            _LOGGER.debug(
+                "Stats: %d solves, %d ms total",
+                solve_count,
+                total_time,
+            )
+            return True
+        except (struct.error, IndexError) as err:
+            _LOGGER.debug("Failed to parse stats: %s", err)
+            return False
 
-    def add_state_callback(self, callback: Callable[[], None]) -> None:
-        """Add a callback for state changes."""
-        self._state_callbacks.add(callback)
+    def _parse_cube_type_message(self, data: bytearray) -> bool:
+        """Parse cube type/model identification message."""
+        if len(data) < 4:
+            return False
 
-    def remove_state_callback(self, callback: Callable[[], None]) -> None:
-        """Remove a callback for state changes."""
-        self._state_callbacks.discard(callback)
-
-    def add_movement_callback(self, callback: Callable[[str], None]) -> None:
-        """Add a callback for movement events."""
-        self._movement_callbacks.add(callback)
-
-    def remove_movement_callback(self, callback: Callable[[str], None]) -> None:
-        """Remove a callback for movement events."""
-        self._movement_callbacks.discard(callback)
-
-    def _notify_movement(self, movement: str) -> None:
-        """Notify all movement callbacks."""
-        for callback in self._movement_callbacks:
-            try:
-                callback(movement)
-            except Exception as err:
-                _LOGGER.error("Error in movement callback: %s", err)
+        type_byte = data[3]
+        type_map = {
+            0x00: "GoCube",
+            0x01: "GoCube Edge",
+            0x02: "GoCube Pro",
+            0x35: "GoCube",
+        }
+        self.data.cube_type = type_map.get(type_byte, f"Unknown (0x{type_byte:02x})")
+        _LOGGER.debug("Cube type: %s", self.data.cube_type)
+        return True

--- a/custom_components/gocube/gocube_ble/renderer.py
+++ b/custom_components/gocube/gocube_ble/renderer.py
@@ -1,0 +1,164 @@
+"""Isometric SVG renderer for GoCube state visualization."""
+
+from __future__ import annotations
+
+import math
+
+from .const import COLOR_RGB, ISOMETRIC_FACES
+
+# Rendering constants
+CELL_SIZE = 40
+GAP = 2
+STROKE_COLOR = "#333333"
+STROKE_WIDTH = 1.5
+BACKGROUND_COLOR = "#1a1a1a"
+UNKNOWN_COLOR = "#808080"
+
+# Isometric projection basis vectors
+_DX = CELL_SIZE * math.sqrt(3) / 2
+_DY = CELL_SIZE / 2
+
+
+def _iso_point(apex: tuple[float, float], right: int, left: int, down: int) -> tuple[float, float]:
+    """Compute screen coordinates from isometric grid position.
+
+    Args:
+        apex: The (x, y) screen position of the cube's front apex.
+        right: Steps along the right-down axis.
+        left: Steps along the left-down axis.
+        down: Steps along the vertical-down axis.
+    """
+    x = apex[0] + right * _DX - left * _DX
+    y = apex[1] + right * _DY + left * _DY + down * CELL_SIZE
+    return (x, y)
+
+
+def _polygon_points(corners: list[tuple[float, float]]) -> str:
+    """Format corner coordinates as SVG polygon points string."""
+    return " ".join(f"{x:.1f},{y:.1f}" for x, y in corners)
+
+
+def _shrink_polygon(corners: list[tuple[float, float]], gap: float) -> list[tuple[float, float]]:
+    """Shrink a polygon inward by `gap` pixels to create inter-sticker gaps."""
+    cx = sum(p[0] for p in corners) / len(corners)
+    cy = sum(p[1] for p in corners) / len(corners)
+    result = []
+    for px, py in corners:
+        dx = px - cx
+        dy = py - cy
+        dist = math.sqrt(dx * dx + dy * dy)
+        if dist > 0:
+            factor = (dist - gap) / dist
+            result.append((cx + dx * factor, cy + dy * factor))
+        else:
+            result.append((px, py))
+    return result
+
+
+def _sticker_color(face_colors: dict[str, list[str]], face_name: str, index: int) -> str:
+    """Get the RGB hex color for a sticker."""
+    if face_name not in face_colors:
+        return UNKNOWN_COLOR
+    stickers = face_colors[face_name]
+    if index >= len(stickers):
+        return UNKNOWN_COLOR
+    color_name = stickers[index]
+    return COLOR_RGB.get(color_name, UNKNOWN_COLOR)
+
+
+def render_cube_svg(
+    face_colors: dict[str, list[str]] | None = None,
+    top_face: str = "White",
+    right_face: str = "Blue",
+    left_face: str = "Red",
+) -> str:
+    """Render an isometric cube as an SVG string.
+
+    Args:
+        face_colors: Dict mapping face name to list of 9 color names in row-major
+                     order [TL, TC, TR, ML, C, MR, BL, BC, BR].
+                     If None, renders a grey cube.
+        top_face: Name of the face to render on top.
+        right_face: Name of the face to render on the right.
+        left_face: Name of the face to render on the left.
+
+    Returns:
+        SVG markup string.
+    """
+    if face_colors is None:
+        face_colors = {}
+
+    margin = 8
+    width = 6 * _DX + 2 * margin
+    height = 6 * _DY + 3 * CELL_SIZE + 2 * margin
+    apex = (width / 2, margin)
+
+    polygons: list[str] = []
+
+    # --- Top face ---
+    # Grid: row goes along left axis, col goes along right axis
+    for row in range(3):
+        for col in range(3):
+            corners = [
+                _iso_point(apex, col, row, 0),
+                _iso_point(apex, col + 1, row, 0),
+                _iso_point(apex, col + 1, row + 1, 0),
+                _iso_point(apex, col, row + 1, 0),
+            ]
+            corners = _shrink_polygon(corners, GAP)
+            # Map grid position to sticker index (row-major in face coordinates)
+            # Top face: isometric row=face_row, isometric col=face_col
+            sticker_idx = row * 3 + col
+            color = _sticker_color(face_colors, top_face, sticker_idx)
+            polygons.append(
+                f'  <polygon points="{_polygon_points(corners)}" '
+                f'fill="{color}" stroke="{STROKE_COLOR}" stroke-width="{STROKE_WIDTH}"/>'
+            )
+
+    # --- Left face ---
+    # Grid: row goes down, col goes along the left-down axis
+    # Anchored at left=3 (left edge of top face) — renders on viewer's LEFT
+    for row in range(3):
+        for col in range(3):
+            corners = [
+                _iso_point(apex, col, 3, row),
+                _iso_point(apex, col + 1, 3, row),
+                _iso_point(apex, col + 1, 3, row + 1),
+                _iso_point(apex, col, 3, row + 1),
+            ]
+            corners = _shrink_polygon(corners, GAP)
+            sticker_idx = row * 3 + col
+            color = _sticker_color(face_colors, left_face, sticker_idx)
+            polygons.append(
+                f'  <polygon points="{_polygon_points(corners)}" '
+                f'fill="{color}" stroke="{STROKE_COLOR}" stroke-width="{STROKE_WIDTH}"/>'
+            )
+
+    # --- Right face ---
+    # Grid: row goes down, col goes along the right-down axis
+    # Anchored at right=3 (right edge of top face) — renders on viewer's RIGHT
+    for row in range(3):
+        for col in range(3):
+            corners = [
+                _iso_point(apex, 3, col, row),
+                _iso_point(apex, 3, col + 1, row),
+                _iso_point(apex, 3, col + 1, row + 1),
+                _iso_point(apex, 3, col, row + 1),
+            ]
+            corners = _shrink_polygon(corners, GAP)
+            sticker_idx = row * 3 + col
+            color = _sticker_color(face_colors, right_face, sticker_idx)
+            polygons.append(
+                f'  <polygon points="{_polygon_points(corners)}" '
+                f'fill="{color}" stroke="{STROKE_COLOR}" stroke-width="{STROKE_WIDTH}"/>'
+            )
+
+    svg_content = "\n".join(polygons)
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width:.0f} {height:.0f}" '
+        f'width="{width:.0f}" height="{height:.0f}">\n'
+        f'  <rect width="100%" height="100%" fill="{BACKGROUND_COLOR}" rx="8"/>\n'
+        f"{svg_content}\n"
+        f"</svg>"
+    )

--- a/custom_components/gocube/image.py
+++ b/custom_components/gocube/image.py
@@ -1,0 +1,90 @@
+"""Support for GoCube visualization as an image entity."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, SIGNAL_STATE_UPDATE
+from .gocube_ble.renderer import render_cube_svg
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up GoCube image entity."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([GoCubeImageEntity(coordinator, entry)])
+
+
+class GoCubeImageEntity(ImageEntity):
+    """Isometric cube visualization entity."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Cube View"
+    _attr_content_type = "image/svg+xml"
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        """Initialize the image entity."""
+        super().__init__(coordinator.hass)
+        self.coordinator = coordinator
+        address = entry.data[CONF_ADDRESS]
+        self._attr_unique_id = f"{address}_cube_view"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, address)},
+            "name": entry.title,
+            "model": "GoCube",
+            "manufacturer": "GoCube",
+        }
+        self._address = address
+        self._cached_svg: bytes | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register dispatcher listener."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SIGNAL_STATE_UPDATE}_{self._address}",
+                self._handle_update,
+            )
+        )
+        # Generate initial image
+        self._update_image()
+
+    @callback
+    def _handle_update(self) -> None:
+        """Handle state update — re-render the cube."""
+        self._update_image()
+        self.async_write_ha_state()
+
+    def _update_image(self) -> None:
+        """Re-render the SVG from current face data."""
+        face_colors = self.coordinator.data.face_colors or None
+        svg = render_cube_svg(face_colors=face_colors)
+        self._cached_svg = svg.encode("utf-8")
+        from datetime import datetime
+        self._attr_image_last_updated = datetime.now()
+
+    async def async_image(self) -> bytes | None:
+        """Return the current cube image."""
+        return self._cached_svg
+
+    @property
+    def available(self) -> bool:
+        """Return True once we've received state data."""
+        return self.coordinator.has_been_seen
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return True when disconnected (image is cached)."""
+        return not self.coordinator.is_connected

--- a/custom_components/gocube/light.py
+++ b/custom_components/gocube/light.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
     ATTR_EFFECT,
     ColorMode,
     LightEntity,
@@ -13,18 +14,30 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
-from .gocube_ble.ble import GoCubeConnection
+from .const import DOMAIN, SIGNAL_STATE_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
-# Effect names
 EFFECT_FLASH = "Flash"
 EFFECT_FLASH_SLOW = "Flash Slow"
 EFFECT_ANIMATION = "Animation"
+
+# 7 brightness levels: 0x45 (brightest) → 0x4B (off)
+# Map to command names in CONFIGURATION_COMMANDS
+_BRIGHTNESS_LEVELS = [
+    "LedBrightnessOff",  # level 0
+    "LedBrightness1",    # level 1
+    "LedBrightness2",    # level 2
+    "LedBrightness3",    # level 3
+    "LedBrightness4",    # level 4
+    "LedBrightness5",    # level 5
+    "LedBrightness6",    # level 6 (max)
+]
 
 LIGHT_TYPES: dict[str, LightEntityDescription] = {
     "status": LightEntityDescription(
@@ -35,65 +48,77 @@ LIGHT_TYPES: dict[str, LightEntityDescription] = {
 }
 
 
+def _brightness_to_level(brightness: int) -> int:
+    """Map HA brightness (1-255) to cube level (1-6)."""
+    # 6 visible levels, evenly spaced across 1-255
+    return min(6, max(1, round(brightness * 6 / 255)))
+
+
+def _level_to_brightness(level: int) -> int:
+    """Map cube level (0-6) to HA brightness (0-255)."""
+    return round(level * 255 / 6)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the GoCube lights."""
-    connection = hass.data[DOMAIN][entry.entry_id]["connection"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        GoCubeLight(connection, entry, description)
+        GoCubeLight(coordinator, entry, description)
         for description in LIGHT_TYPES.values()
     )
 
 
 class GoCubeLight(LightEntity):
-    """Representation of a GoCube light."""
+    """GoCube light entity with brightness support."""
 
     _attr_has_entity_name = True
     _attr_should_poll = False
-    _attr_supported_color_modes = {ColorMode.ONOFF}
-    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_features = LightEntityFeature.EFFECT
     _attr_effect_list = [EFFECT_FLASH, EFFECT_FLASH_SLOW, EFFECT_ANIMATION]
 
-    def __init__(
-        self,
-        connection: GoCubeConnection,
-        entry: ConfigEntry,
-        description: LightEntityDescription,
-    ) -> None:
+    def __init__(self, coordinator, entry: ConfigEntry, description: LightEntityDescription) -> None:
         """Initialize the light."""
-        self.connection = connection
+        self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{entry.data['address']}_{description.key}"
+        address = entry.data[CONF_ADDRESS]
+        self._attr_unique_id = f"{address}_{description.key}"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry.data["address"])},
+            "identifiers": {(DOMAIN, address)},
             "name": entry.title,
             "model": "GoCube",
             "manufacturer": "GoCube",
         }
         self._attr_is_on = False
-        self._attr_available = False
-        self._unsubscribe = None
+        self._attr_brightness = 255
+        self._level = 6  # Current cube brightness level (0-6)
         self._effect = None
+        self._address = address
 
     async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        self._unsubscribe = self.connection.register_callback(self._handle_state_change)
-        # Initial state update
+        """Register dispatcher listener."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SIGNAL_STATE_UPDATE}_{self._address}",
+                self._handle_update,
+            )
+        )
+
+    @callback
+    def _handle_update(self) -> None:
+        """Handle state update."""
         self.async_write_ha_state()
 
-    def _handle_state_change(self) -> None:
-        """Handle state changes."""
-        _LOGGER.debug(
-            "Light %s state changed: available=%s, is_on=%s",
-            self.entity_description.key,
-            self.available,
-            self.is_on,
-        )
-        self.async_write_ha_state()
+    @property
+    def available(self) -> bool:
+        """Return True when connected (light requires active connection)."""
+        return self.coordinator.is_connected
 
     @property
     def is_on(self) -> bool:
@@ -101,13 +126,9 @@ class GoCubeLight(LightEntity):
         return self._attr_is_on
 
     @property
-    def available(self) -> bool:
-        """Return if the light is available."""
-        return (
-            self.connection._is_connected
-            and self.connection._client is not None
-            and self.connection._client.is_connected
-        )
+    def brightness(self) -> int | None:
+        """Return the brightness."""
+        return self._attr_brightness if self._attr_is_on else None
 
     @property
     def effect(self) -> str | None:
@@ -115,30 +136,42 @@ class GoCubeLight(LightEntity):
         return self._effect
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the light on."""
+        """Turn the light on, optionally with brightness or effect."""
         try:
             if ATTR_EFFECT in kwargs:
                 effect = kwargs[ATTR_EFFECT]
                 if effect == EFFECT_FLASH:
-                    await self.connection.led_flash()
+                    await self.coordinator.connection.send_command("LedFlash")
                     self._effect = EFFECT_FLASH
-                    # Flash effect is temporary, set state to off
                     self._attr_is_on = False
                 elif effect == EFFECT_FLASH_SLOW:
-                    await self.connection.led_flash_slow()
+                    await self.coordinator.connection.send_command("LedFlashSlow")
                     self._effect = EFFECT_FLASH_SLOW
-                    # Flash slow effect is temporary, set state to off
                     self._attr_is_on = False
                 elif effect == EFFECT_ANIMATION:
-                    await self.connection.led_toggle_animation()
+                    await self.coordinator.connection.send_command("LedToggleAnimation")
                     self._effect = EFFECT_ANIMATION
                 else:
                     self._effect = None
                     self._attr_is_on = True
-            else:
-                await self.connection.led_toggle()
-                self._effect = None
+            elif ATTR_BRIGHTNESS in kwargs:
+                level = _brightness_to_level(kwargs[ATTR_BRIGHTNESS])
+                if not self._attr_is_on:
+                    await self.coordinator.connection.send_command("LedToggle")
+                await self.coordinator.connection.send_command(_BRIGHTNESS_LEVELS[level])
+                self._level = level
+                self._attr_brightness = _level_to_brightness(level)
                 self._attr_is_on = True
+                self._effect = None
+            else:
+                # Turn on at last known brightness
+                await self.coordinator.connection.send_command("LedToggle")
+                level = self._level if self._level > 0 else 6
+                await self.coordinator.connection.send_command(_BRIGHTNESS_LEVELS[level])
+                self._level = level
+                self._attr_brightness = _level_to_brightness(level)
+                self._attr_is_on = True
+                self._effect = None
             self.async_write_ha_state()
         except Exception as err:
             _LOGGER.error("Failed to turn on light: %s", err)
@@ -148,7 +181,7 @@ class GoCubeLight(LightEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         try:
-            await self.connection.led_toggle()
+            await self.coordinator.connection.send_command("LedToggle")
             self._attr_is_on = False
             self._effect = None
             self.async_write_ha_state()
@@ -156,8 +189,3 @@ class GoCubeLight(LightEntity):
             _LOGGER.error("Failed to turn off light: %s", err)
             self._attr_is_on = True
             self.async_write_ha_state()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed."""
-        if self._unsubscribe:
-            self._unsubscribe()

--- a/custom_components/gocube/manifest.json
+++ b/custom_components/gocube/manifest.json
@@ -9,7 +9,7 @@
     "codeowners": [],
     "config_flow": true,
     "dependencies": [
-        "bluetooth_adapters"
+        "bluetooth"
     ],
     "documentation": "https://github.com/anthonyangel/gocube-ha",
     "integration_type": "device",
@@ -21,8 +21,7 @@
     ],
     "quality_scale": "custom",
     "requirements": [
-        "bleak>=0.21.0",
-        "bleak-retry-connector>=0.3.0"
+        "bleak>=0.21.0"
     ],
-    "version": "1.1.0"
+    "version": "2.0.0"
 }

--- a/custom_components/gocube/sensor.py
+++ b/custom_components/gocube/sensor.py
@@ -2,22 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Any
-from datetime import datetime
+import logging
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
-    EntityCategory,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-import logging
 
-from .const import DOMAIN
-from .gocube_ble.ble import GoCubeConnection
+from .const import DOMAIN, SIGNAL_STATE_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +27,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         name="Battery",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
@@ -40,32 +41,26 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         key="solved_faces",
         name="Solved Faces",
         native_unit_of_measurement="faces",
+        state_class=SensorStateClass.MEASUREMENT,
+        has_entity_name=True,
+    ),
+    "cube_type": SensorEntityDescription(
+        key="cube_type",
+        name="Cube Type",
         entity_category=EntityCategory.DIAGNOSTIC,
         has_entity_name=True,
     ),
-    # "rssi": SensorEntityDescription(
-    #     key="rssi",
-    #     name="Signal Strength",
-    #     device_class="signal_strength",
-    #     native_unit_of_measurement="dBm",
-    #     translation_key="rssi",
-    # ),
-    # "last_update": SensorEntityDescription(
-    #     key="last_update",
-    #     name="Last Update",
-    #     device_class="timestamp",
-    #     translation_key="last_update",
-    # ),
-    # "last_move": SensorEntityDescription(
-    #     key="last_move",
-    #     name="Last Move",
-    #     translation_key="last_move",
-    # ),
-    # "cube_type": SensorEntityDescription(
-    #     key="cube_type",
-    #     name="Cube Type",
-    #     translation_key="cube_type",
-    # ),
+    "state_fingerprint": SensorEntityDescription(
+        key="state_fingerprint",
+        name="State Fingerprint",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        has_entity_name=True,
+    ),
+    "pattern": SensorEntityDescription(
+        key="pattern",
+        name="Pattern",
+        has_entity_name=True,
+    ),
 }
 
 
@@ -75,107 +70,93 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up GoCube sensors."""
-    connection = hass.data[DOMAIN][entry.entry_id]["connection"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            GoCubeSensor(connection, entry, description)
-            for description in SENSOR_TYPES.values()
-        ]
+        GoCubeSensor(coordinator, entry, description)
+        for description in SENSOR_TYPES.values()
     )
 
 
 class GoCubeSensor(SensorEntity):
-    """Base class for GoCube sensors."""
+    """GoCube sensor entity."""
 
     _attr_has_entity_name = True
-    _attr_should_poll = True
+    _attr_should_poll = False
 
-    def __init__(
-        self,
-        connection: GoCubeConnection,
-        entry: ConfigEntry,
-        description: SensorEntityDescription,
-    ) -> None:
+    def __init__(self, coordinator, entry: ConfigEntry, description: SensorEntityDescription) -> None:
         """Initialize the sensor."""
-        self.connection = connection
+        self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{entry.data['address']}_{description.key}"
+        address = entry.data[CONF_ADDRESS]
+        self._attr_unique_id = f"{address}_{description.key}"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry.data["address"])},
+            "identifiers": {(DOMAIN, address)},
             "name": entry.title,
             "model": "GoCube",
             "manufacturer": "GoCube",
         }
-        self._unsubscribe = self.connection.register_callback(self._handle_state_change)
+        self._address = address
 
-    def _handle_state_change(self) -> None:
-        """Handle state changes."""
+    async def async_added_to_hass(self) -> None:
+        """Register dispatcher listener."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SIGNAL_STATE_UPDATE}_{self._address}",
+                self._handle_update,
+            )
+        )
+
+    @callback
+    def _handle_update(self) -> None:
+        """Handle state update."""
         self.async_write_ha_state()
 
     @property
     def available(self) -> bool:
-        """Return if entity is available."""
-        return (
-            self.connection._is_connected
-            and self.connection._client is not None
-            and self.connection._client.is_connected
-        )
+        """Return True once we've received any data from the cube."""
+        # Connection state sensor is always available
+        if self.entity_description.key == "connection_state":
+            return True
+        return self.coordinator.has_been_seen
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return True when disconnected (values are cached)."""
+        return not self.coordinator.is_connected
 
     @property
     def native_value(self) -> str | int | float | None:
-        """Return the native value."""
-        if not self.available:
+        """Return the sensor value."""
+        data = self.coordinator.data
+        key = self.entity_description.key
+
+        if key == "battery":
+            return data.battery_level
+        if key == "connection_state":
+            if self.coordinator.is_connected:
+                return "connected"
+            if self.coordinator.has_been_seen:
+                return "disconnected"
+            return "not_seen"
+        if key == "solved_faces":
+            if data.face_states:
+                return sum(1 for v in data.face_states.values() if v)
+            return 0
+        if key == "cube_type":
+            return data.cube_type
+        if key == "state_fingerprint":
+            return data.state_fingerprint
+        if key == "pattern":
+            # Check built-in patterns first
+            match = data.matched_pattern
+            if match:
+                return match
+            # Check user-saved patterns
+            fp = data.state_fingerprint
+            if fp:
+                store = self.hass.data.get(DOMAIN, {}).get("pattern_store")
+                if store:
+                    return store.match(fp)
             return None
-
-        value = None
-        if self.entity_description.key == "battery":
-            value = self.connection.data.battery_level
-        elif self.entity_description.key == "connection_state":
-            # Only show connected if we have received data
-            value = (
-                "connected"
-                if self.connection.data.battery_level is not None
-                else "connecting"
-            )
-        elif self.entity_description.key == "solved_faces":
-            # Count the number of solved faces
-            if self.connection.data.face_states:
-                value = sum(
-                    1
-                    for face_solved in self.connection.data.face_states.values()
-                    if face_solved
-                )
-            else:
-                value = 0
-        # elif self.entity_description.key == "rssi":
-        #     value = self.connection.data.rssi
-        # elif self.entity_description.key == "last_update":
-        #     if self.connection.data.last_update:
-        #         value = datetime.fromtimestamp(self.connection.data.last_update).isoformat()
-        # elif self.entity_description.key == "last_move":
-        #     value = self.connection.data.last_move
-        # elif self.entity_description.key == "cube_type":
-        #     value = self.connection.data.cube_type
-
-        _LOGGER.debug(
-            "Sensor %s value: %s (data: %s)",
-            self.entity_description.key,
-            value,
-            self.connection.data,
-        )
-        return value
-
-    async def async_update(self) -> None:
-        """Update the sensor."""
-        if not self.available:
-            return
-
-        try:
-            if self.entity_description.key == "battery":
-                await self.connection.send_command("GetBattery")
-        except Exception as err:
-            _LOGGER.error("Failed to update sensor: %s", err)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed."""
-        self._unsubscribe()
+        return None

--- a/custom_components/gocube/services.yaml
+++ b/custom_components/gocube/services.yaml
@@ -1,0 +1,36 @@
+save_pattern:
+  name: Save pattern
+  description: Save the current cube state as a named pattern.
+  target:
+    device:
+      integration: gocube
+  fields:
+    name:
+      name: Name
+      description: A name for this pattern (e.g. "Movie Time").
+      required: true
+      example: "Movie Time"
+      selector:
+        text:
+
+delete_pattern:
+  name: Delete pattern
+  description: Delete a saved pattern by name.
+  target:
+    device:
+      integration: gocube
+  fields:
+    name:
+      name: Name
+      description: The name of the pattern to delete.
+      required: true
+      example: "Movie Time"
+      selector:
+        text:
+
+list_patterns:
+  name: List patterns
+  description: Log all saved and built-in patterns to the Home Assistant log.
+  target:
+    device:
+      integration: gocube

--- a/custom_components/gocube/switch.py
+++ b/custom_components/gocube/switch.py
@@ -7,12 +7,13 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
-from .gocube_ble.ble import GoCubeConnection
+from .const import DOMAIN, SIGNAL_STATE_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,64 +33,64 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up GoCube switch based on a config entry."""
-    connection = hass.data[DOMAIN][entry.entry_id]["connection"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        GoCubeSwitch(connection, entry, description)
+        GoCubeSwitch(coordinator, entry, description)
         for description in SWITCH_TYPES.values()
     )
 
 
 class GoCubeSwitch(SwitchEntity):
-    """Defines a GoCube switch."""
+    """GoCube switch entity."""
 
     _attr_has_entity_name = True
 
-    def __init__(
-        self,
-        connection: GoCubeConnection,
-        entry: ConfigEntry,
-        description: SwitchEntityDescription,
-    ) -> None:
+    def __init__(self, coordinator, entry: ConfigEntry, description: SwitchEntityDescription) -> None:
         """Initialize the switch."""
-        self.connection = connection
+        self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{entry.data['address']}_{description.key}"
+        address = entry.data[CONF_ADDRESS]
+        self._attr_unique_id = f"{address}_{description.key}"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry.data["address"])},
+            "identifiers": {(DOMAIN, address)},
             "name": entry.title,
             "model": "GoCube",
             "manufacturer": "GoCube",
         }
-        self._unsubscribe = None
+        self._address = address
 
     async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        self._unsubscribe = self.connection.register_callback(self._handle_state_change)
+        """Register dispatcher listener."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SIGNAL_STATE_UPDATE}_{self._address}",
+                self._handle_update,
+            )
+        )
 
-    def _handle_state_change(self) -> None:
-        """Handle state changes."""
+    @callback
+    def _handle_update(self) -> None:
+        """Handle state update."""
         self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool:
         """Return the state of the switch."""
-        if self.entity_description.key == "auto_reconnect":
-            return self.connection.should_auto_reconnect
-        return False
+        return self.coordinator.should_auto_reconnect
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
-        if self.entity_description.key == "auto_reconnect":
-            await self.connection.enable_auto_reconnect()
-            self.async_write_ha_state()
+        """Enable auto-reconnect."""
+        self.coordinator.should_auto_reconnect = True
+        # If disconnected, try to reconnect now
+        if not self.coordinator.is_connected:
+            try:
+                await self.coordinator.async_connect()
+            except Exception:
+                pass
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
-        if self.entity_description.key == "auto_reconnect":
-            await self.connection.disconnect()  # This also disables auto-reconnect
-            self.async_write_ha_state()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed."""
-        if self._unsubscribe:
-            self._unsubscribe() 
+        """Disable auto-reconnect (does NOT disconnect)."""
+        self.coordinator.should_auto_reconnect = False
+        self.async_write_ha_state()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "gocube-ha"
+version = "2.0.0"
+description = "GoCube Home Assistant integration"
+requires-python = ">=3.12"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["custom_components/gocube"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,126 @@
+"""Tests for GoCube data models."""
+
+from gocube_ble.models import KNOWN_PATTERNS, CubeStats, GoCubeData, Orientation
+
+
+class TestOrientation:
+    def test_defaults(self):
+        o = Orientation()
+        assert o.x == 0.0
+        assert o.y == 0.0
+        assert o.z == 0.0
+        assert o.w == 1.0
+
+    def test_custom_values(self):
+        o = Orientation(x=0.5, y=-0.5, z=0.25, w=0.75)
+        assert o.x == 0.5
+        assert o.w == 0.75
+
+
+class TestCubeStats:
+    def test_defaults(self):
+        s = CubeStats()
+        assert s.solve_count == 0
+        assert s.total_solve_time_ms == 0
+
+
+class TestGoCubeData:
+    def test_defaults(self):
+        d = GoCubeData()
+        assert d.battery_level is None
+        assert d.is_solved is False
+        assert d.face_states == {}
+        assert d.face_colors == {}
+        assert d.orientation is None
+        assert d.stats is None
+        assert d.cube_type is None
+        assert d.last_move is None
+
+    def test_mutable_defaults_are_independent(self):
+        """Each instance should get its own dict."""
+        d1 = GoCubeData()
+        d2 = GoCubeData()
+        d1.face_states["White"] = True
+        assert "White" not in d2.face_states
+
+    def test_fingerprint_none_when_no_data(self):
+        d = GoCubeData()
+        assert d.state_fingerprint is None
+
+    def test_fingerprint_solved_cube(self):
+        d = GoCubeData()
+        for face, color in [
+            ("White", "White"), ("Yellow", "Yellow"), ("Blue", "Blue"),
+            ("Green", "Green"), ("Red", "Red"), ("Orange", "Orange"),
+        ]:
+            d.face_colors[face] = [color] * 9
+        assert d.state_fingerprint == "WWWWWWWWWYYYYYYYYYBBBBBBBBBGGGGGGGGGRRRRRRRRROOOOOOOOO"
+
+    def test_fingerprint_deterministic(self):
+        d = GoCubeData()
+        for face, color in [
+            ("White", "White"), ("Yellow", "Yellow"), ("Blue", "Blue"),
+            ("Green", "Green"), ("Red", "Red"), ("Orange", "Orange"),
+        ]:
+            d.face_colors[face] = [color] * 9
+        # Scramble one sticker
+        d.face_colors["White"][0] = "Red"
+        fp1 = d.state_fingerprint
+        fp2 = d.state_fingerprint
+        assert fp1 == fp2
+        assert fp1.startswith("R")  # First sticker is now Red
+        assert len(fp1) == 54
+
+    def test_fingerprint_none_with_partial_data(self):
+        d = GoCubeData()
+        d.face_colors["White"] = ["White"] * 9
+        assert d.state_fingerprint is None
+
+    def test_matched_pattern_solved(self):
+        d = GoCubeData()
+        for face, color in [
+            ("White", "White"), ("Yellow", "Yellow"), ("Blue", "Blue"),
+            ("Green", "Green"), ("Red", "Red"), ("Orange", "Orange"),
+        ]:
+            d.face_colors[face] = [color] * 9
+        assert d.matched_pattern == "Solved"
+
+    def test_matched_pattern_checkerboard(self):
+        d = GoCubeData()
+        d.face_colors["White"] = ["W", "Y", "W", "Y", "W", "Y", "W", "Y", "W"]
+        d.face_colors["Yellow"] = ["Y", "W", "Y", "W", "Y", "W", "Y", "W", "Y"]
+        d.face_colors["Blue"] = ["B", "G", "B", "G", "B", "G", "B", "G", "B"]
+        d.face_colors["Green"] = ["G", "B", "G", "B", "G", "B", "G", "B", "G"]
+        d.face_colors["Red"] = ["R", "O", "R", "O", "R", "O", "R", "O", "R"]
+        d.face_colors["Orange"] = ["O", "R", "O", "R", "O", "R", "O", "R", "O"]
+        # Uses abbreviations, but face_colors stores full names from parser
+        # Let me fix this test to use full color names
+        assert d.matched_pattern is None  # single-letter names won't match
+
+    def test_matched_pattern_checkerboard_full_names(self):
+        d = GoCubeData()
+        d.face_colors["White"] = ["White", "Yellow", "White", "Yellow", "White", "Yellow", "White", "Yellow", "White"]
+        d.face_colors["Yellow"] = ["Yellow", "White", "Yellow", "White", "Yellow", "White", "Yellow", "White", "Yellow"]
+        d.face_colors["Blue"] = ["Blue", "Green", "Blue", "Green", "Blue", "Green", "Blue", "Green", "Blue"]
+        d.face_colors["Green"] = ["Green", "Blue", "Green", "Blue", "Green", "Blue", "Green", "Blue", "Green"]
+        d.face_colors["Red"] = ["Red", "Orange", "Red", "Orange", "Red", "Orange", "Red", "Orange", "Red"]
+        d.face_colors["Orange"] = ["Orange", "Red", "Orange", "Red", "Orange", "Red", "Orange", "Red", "Orange"]
+        assert d.matched_pattern == "Checkerboard"
+
+    def test_matched_pattern_none_when_scrambled(self):
+        d = GoCubeData()
+        for face, color in [
+            ("White", "White"), ("Yellow", "Yellow"), ("Blue", "Blue"),
+            ("Green", "Green"), ("Red", "Red"), ("Orange", "Orange"),
+        ]:
+            d.face_colors[face] = [color] * 9
+        d.face_colors["White"][0] = "Red"
+        assert d.matched_pattern is None
+
+    def test_matched_pattern_none_without_data(self):
+        d = GoCubeData()
+        assert d.matched_pattern is None
+
+    def test_known_patterns_are_54_chars(self):
+        for name, fp in KNOWN_PATTERNS.items():
+            assert len(fp) == 54, f"{name} pattern is {len(fp)} chars, expected 54"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,310 @@
+"""Tests for GoCube BLE protocol parser."""
+
+import struct
+
+import pytest
+
+from gocube_ble.const import (
+    MSG_TYPE_BATTERY,
+    MSG_TYPE_CUBE_TYPE,
+    MSG_TYPE_ORIENTATION,
+    MSG_TYPE_ROTATION,
+    MSG_TYPE_STATE,
+    MSG_TYPE_STATS,
+)
+from gocube_ble.parser import GoCubeDataParser
+
+
+@pytest.fixture
+def parser():
+    """Return a fresh parser instance."""
+    return GoCubeDataParser()
+
+
+def _make_msg(msg_type: int, payload: bytes = b"") -> bytearray:
+    """Build a minimal GoCube message: [prefix, length, type, ...payload]."""
+    prefix = 0x2A
+    length = len(payload) + 1  # type byte + payload
+    return bytearray([prefix, length, msg_type]) + bytearray(payload)
+
+
+# --- Message framing ---
+
+
+class TestMessageFraming:
+    def test_too_short_message(self, parser):
+        result = parser.parse_message(bytearray([0x2A, 0x01]))
+        assert result == []
+
+    def test_empty_message(self, parser):
+        result = parser.parse_message(bytearray())
+        assert result == []
+
+    def test_unknown_message_type(self, parser):
+        result = parser.parse_message(_make_msg(0xFF))
+        assert result == []
+
+    def test_message_without_prefix(self, parser):
+        """Messages without 0x2A prefix are still processed (type at index 2)."""
+        msg = bytearray([0x00, 0x04, MSG_TYPE_BATTERY, 75, 0x00])
+        # Fix checksum
+        msg[4] = sum(msg[:4]) % 0x100
+        result = parser.parse_message(msg)
+        assert "battery" in result
+
+
+# --- Rotation messages ---
+
+
+class TestRotation:
+    def test_known_rotations(self, parser):
+        """Each known rotation byte should be parsed correctly."""
+        expected = {
+            0x00: "Blue Clockwise",
+            0x01: "Blue Counterclockwise",
+            0x02: "Green Clockwise",
+            0x03: "Green Counterclockwise",
+            0x04: "White Clockwise",
+            0x05: "White Counterclockwise",
+            0x06: "Yellow Clockwise",
+            0x07: "Yellow Counterclockwise",
+            0x08: "Red Clockwise",
+            0x09: "Red Counterclockwise",
+            0x0A: "Orange Clockwise",
+            0x0B: "Orange Counterclockwise",
+        }
+        for byte_val, desc in expected.items():
+            p = GoCubeDataParser()
+            result = p.parse_message(_make_msg(MSG_TYPE_ROTATION, bytes([byte_val])))
+            assert "rotation" in result
+            assert p.data.last_move == desc
+
+    def test_unknown_rotation_byte(self, parser):
+        result = parser.parse_message(_make_msg(MSG_TYPE_ROTATION, bytes([0xFF])))
+        assert result == []
+        assert parser.data.last_move is None
+
+    def test_rotation_message_too_short(self, parser):
+        """Rotation message needs at least 4 bytes (prefix, len, type, face_byte)."""
+        result = parser.parse_message(bytearray([0x2A, 0x01, MSG_TYPE_ROTATION]))
+        assert result == []
+
+
+# --- State messages ---
+
+
+def _make_solved_state() -> bytearray:
+    """Build a solved cube state message (54 color bytes, all faces uniform)."""
+    # 6 faces, 9 bytes each. Byte 0 = center color ID, bytes 1-8 = same color.
+    state_bytes = bytearray()
+    for color_id in range(6):
+        state_bytes.extend([color_id] * 9)
+    return _make_msg(MSG_TYPE_STATE, bytes(state_bytes))
+
+
+def _make_scrambled_state() -> bytearray:
+    """Build a state with the White face having a Red sticker at UL."""
+    state_bytes = bytearray()
+    for color_id in range(6):
+        face = [color_id] * 9
+        if color_id == 2:  # White face
+            face[1] = 4  # Surround sticker 0 (UL) = Red
+        state_bytes.extend(face)
+    return _make_msg(MSG_TYPE_STATE, bytes(state_bytes))
+
+
+class TestState:
+    def test_solved_cube(self, parser):
+        result = parser.parse_message(_make_solved_state())
+        assert "state" in result
+        assert parser.data.is_solved is True
+        assert all(parser.data.face_states.values())
+        assert len(parser.data.face_colors) == 6
+
+    def test_face_names(self, parser):
+        parser.parse_message(_make_solved_state())
+        expected_faces = {"Blue", "Green", "White", "Yellow", "Red", "Orange"}
+        assert set(parser.data.face_colors.keys()) == expected_faces
+
+    def test_solved_face_colors(self, parser):
+        """Each solved face should have 9 identical color entries."""
+        parser.parse_message(_make_solved_state())
+        for face_name, stickers in parser.data.face_colors.items():
+            assert len(stickers) == 9
+            assert all(c == face_name for c in stickers), f"{face_name} not uniform: {stickers}"
+
+    def test_scrambled_face(self, parser):
+        parser.parse_message(_make_scrambled_state())
+        assert parser.data.is_solved is False
+        # White face should not be solved
+        assert parser.data.face_states["White"] is False
+        # White face UL sticker should be Red
+        white_stickers = parser.data.face_colors["White"]
+        assert white_stickers[0] == "Red"  # UL position
+
+    def test_sticker_grid_ordering(self, parser):
+        """Verify the clockwise-to-row-major mapping.
+
+        Surrounding bytes are clockwise: [UL, U, UR, R, DR, D, DL, L]
+        Row-major grid should be:
+            [UL, U, UR, L, C, R, DL, D, DR]
+        """
+        # Build White face with distinct stickers
+        # Center=White(0x02), surround: [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x01]
+        # = [Blue, Green, White, Yellow, Red, Orange, Blue, Green]
+        face_bytes = bytes([0x02, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x01])
+        # Put this as face block 0, fill rest with solved faces
+        state_bytes = bytearray(face_bytes)
+        for color_id in [0, 1, 3, 4, 5]:  # Skip 2 (White, already done)
+            state_bytes.extend([color_id] * 9)
+        msg = _make_msg(MSG_TYPE_STATE, bytes(state_bytes))
+        parser.parse_message(msg)
+
+        white = parser.data.face_colors["White"]
+        # Surround clockwise: s0=Blue, s1=Green, s2=White, s3=Yellow, s4=Red, s5=Orange, s6=Blue, s7=Green
+        # Grid mapping: [s0, s1, s2, s7, C, s3, s6, s5, s4]
+        assert white[0] == "Blue"    # UL = s0
+        assert white[1] == "Green"   # U  = s1
+        assert white[2] == "White"   # UR = s2
+        assert white[3] == "Green"   # L  = s7
+        assert white[4] == "White"   # C  = center
+        assert white[5] == "Yellow"  # R  = s3
+        assert white[6] == "Blue"    # DL = s6
+        assert white[7] == "Orange"  # D  = s5
+        assert white[8] == "Red"     # DR = s4
+
+    def test_state_message_too_short(self, parser):
+        result = parser.parse_message(_make_msg(MSG_TYPE_STATE, b"\x00" * 10))
+        assert result == []
+
+    def test_unknown_center_color_skipped(self, parser):
+        """Face blocks with unknown center color (>5) should be skipped."""
+        state_bytes = bytearray([0xFF] * 9)  # Unknown center
+        for color_id in range(5):
+            state_bytes.extend([color_id] * 9)
+        msg = _make_msg(MSG_TYPE_STATE, bytes(state_bytes))
+        parser.parse_message(msg)
+        assert 0xFF not in [ord(c[0]) if len(c) == 1 else -1 for c in parser.data.face_colors]
+
+    def test_state_persists_across_messages(self, parser):
+        """Parser should accumulate state across multiple messages."""
+        parser.parse_message(_make_solved_state())
+        assert parser.data.is_solved is True
+        parser.parse_message(_make_scrambled_state())
+        assert parser.data.is_solved is False
+
+
+# --- Battery messages ---
+
+
+class TestBattery:
+    def test_valid_battery(self, parser):
+        battery = 75
+        payload = bytes([battery])
+        msg = _make_msg(MSG_TYPE_BATTERY, payload)
+        # Append checksum (sum of first 4 bytes mod 256)
+        checksum = sum(msg[:4]) % 0x100
+        msg.append(checksum)
+        result = parser.parse_message(msg)
+        assert "battery" in result
+        assert parser.data.battery_level == 75
+
+    def test_battery_full(self, parser):
+        battery = 100
+        msg = _make_msg(MSG_TYPE_BATTERY, bytes([battery]))
+        msg.append(sum(msg[:4]) % 0x100)
+        result = parser.parse_message(msg)
+        assert "battery" in result
+        assert parser.data.battery_level == 100
+
+    def test_battery_zero(self, parser):
+        battery = 0
+        msg = _make_msg(MSG_TYPE_BATTERY, bytes([battery]))
+        msg.append(sum(msg[:4]) % 0x100)
+        result = parser.parse_message(msg)
+        assert "battery" in result
+        assert parser.data.battery_level == 0
+
+    def test_battery_bad_checksum(self, parser):
+        msg = _make_msg(MSG_TYPE_BATTERY, bytes([75]))
+        msg.append(0xFF)  # Wrong checksum
+        result = parser.parse_message(msg)
+        assert result == []
+
+    def test_battery_too_short(self, parser):
+        result = parser.parse_message(_make_msg(MSG_TYPE_BATTERY))
+        assert result == []
+
+
+# --- Orientation messages ---
+
+
+class TestOrientation:
+    def test_valid_orientation(self, parser):
+        # Quaternion (0.5, -0.5, 0.25, 0.75) scaled by 16384
+        x, y, z, w = 8192, -8192, 4096, 12288
+        payload = struct.pack("<hhhh", x, y, z, w)
+        result = parser.parse_message(_make_msg(MSG_TYPE_ORIENTATION, payload))
+        assert "orientation" in result
+        assert parser.data.orientation is not None
+        assert abs(parser.data.orientation.x - 0.5) < 0.001
+        assert abs(parser.data.orientation.y - (-0.5)) < 0.001
+        assert abs(parser.data.orientation.z - 0.25) < 0.001
+        assert abs(parser.data.orientation.w - 0.75) < 0.001
+
+    def test_identity_quaternion(self, parser):
+        """Identity quaternion (0, 0, 0, 1)."""
+        payload = struct.pack("<hhhh", 0, 0, 0, 16384)
+        result = parser.parse_message(_make_msg(MSG_TYPE_ORIENTATION, payload))
+        assert "orientation" in result
+        assert abs(parser.data.orientation.w - 1.0) < 0.001
+
+    def test_orientation_too_short(self, parser):
+        result = parser.parse_message(_make_msg(MSG_TYPE_ORIENTATION, b"\x00" * 4))
+        assert result == []
+
+
+# --- Stats messages ---
+
+
+class TestStats:
+    def test_valid_stats(self, parser):
+        solve_count = 5
+        total_time = 12345  # ms
+        payload = bytes([solve_count]) + struct.pack("<H", total_time) + b"\x00"
+        result = parser.parse_message(_make_msg(MSG_TYPE_STATS, payload))
+        assert "stats" in result
+        assert parser.data.stats is not None
+        assert parser.data.stats.solve_count == 5
+        assert parser.data.stats.total_solve_time_ms == 12345
+
+    def test_stats_too_short(self, parser):
+        result = parser.parse_message(_make_msg(MSG_TYPE_STATS, b"\x00"))
+        assert result == []
+
+
+# --- Cube type messages ---
+
+
+class TestCubeType:
+    def test_known_types(self, parser):
+        expected = {
+            0x00: "GoCube",
+            0x01: "GoCube Edge",
+            0x02: "GoCube Pro",
+            0x35: "GoCube",
+        }
+        for byte_val, name in expected.items():
+            p = GoCubeDataParser()
+            result = p.parse_message(_make_msg(MSG_TYPE_CUBE_TYPE, bytes([byte_val])))
+            assert "cube_type" in result
+            assert p.data.cube_type == name
+
+    def test_unknown_type(self, parser):
+        result = parser.parse_message(_make_msg(MSG_TYPE_CUBE_TYPE, bytes([0xFF])))
+        assert "cube_type" in result
+        assert "Unknown" in parser.data.cube_type
+
+    def test_cube_type_too_short(self, parser):
+        result = parser.parse_message(bytearray([0x2A, 0x01, MSG_TYPE_CUBE_TYPE]))
+        assert result == []

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,150 @@
+"""Tests for GoCube isometric SVG renderer."""
+
+import pytest
+
+from gocube_ble.renderer import (
+    BACKGROUND_COLOR,
+    CELL_SIZE,
+    STROKE_COLOR,
+    UNKNOWN_COLOR,
+    _iso_point,
+    _polygon_points,
+    _shrink_polygon,
+    _sticker_color,
+    render_cube_svg,
+)
+from gocube_ble.const import COLOR_RGB
+
+
+# --- Isometric projection ---
+
+
+class TestIsoPoint:
+    def test_apex_identity(self):
+        """Zero offsets should return the apex."""
+        apex = (100.0, 50.0)
+        assert _iso_point(apex, 0, 0, 0) == apex
+
+    def test_right_moves_right_and_down(self):
+        apex = (100.0, 50.0)
+        x, y = _iso_point(apex, 1, 0, 0)
+        assert x > apex[0]
+        assert y > apex[1]
+
+    def test_left_moves_left_and_down(self):
+        apex = (100.0, 50.0)
+        x, y = _iso_point(apex, 0, 1, 0)
+        assert x < apex[0]
+        assert y > apex[1]
+
+    def test_down_moves_only_down(self):
+        apex = (100.0, 50.0)
+        x, y = _iso_point(apex, 0, 0, 1)
+        assert x == apex[0]
+        assert y == apex[1] + CELL_SIZE
+
+    def test_symmetry(self):
+        """Right 1 + Left 1 should give same y but different x."""
+        apex = (100.0, 50.0)
+        xr, yr = _iso_point(apex, 1, 0, 0)
+        xl, yl = _iso_point(apex, 0, 1, 0)
+        assert abs(yr - yl) < 0.001
+        assert xr > apex[0]
+        assert xl < apex[0]
+
+
+# --- Polygon helpers ---
+
+
+class TestPolygonPoints:
+    def test_format(self):
+        corners = [(10.0, 20.0), (30.0, 40.0)]
+        result = _polygon_points(corners)
+        assert result == "10.0,20.0 30.0,40.0"
+
+
+class TestShrinkPolygon:
+    def test_shrink_reduces_area(self):
+        """Shrunk polygon should be closer to center."""
+        corners = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+        shrunk = _shrink_polygon(corners, 1.0)
+        # Center is (5, 5). All shrunk points should be closer to center.
+        for (ox, oy), (sx, sy) in zip(corners, shrunk):
+            orig_dist = ((ox - 5) ** 2 + (oy - 5) ** 2) ** 0.5
+            shrunk_dist = ((sx - 5) ** 2 + (sy - 5) ** 2) ** 0.5
+            assert shrunk_dist < orig_dist
+
+    def test_zero_gap(self):
+        corners = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+        shrunk = _shrink_polygon(corners, 0.0)
+        for (ox, oy), (sx, sy) in zip(corners, shrunk):
+            assert abs(ox - sx) < 0.001
+            assert abs(oy - sy) < 0.001
+
+
+# --- Sticker color lookup ---
+
+
+class TestStickerColor:
+    def test_known_color(self):
+        face_colors = {"White": ["White"] * 9}
+        assert _sticker_color(face_colors, "White", 0) == COLOR_RGB["White"]
+
+    def test_unknown_face(self):
+        assert _sticker_color({}, "White", 0) == UNKNOWN_COLOR
+
+    def test_index_out_of_range(self):
+        face_colors = {"White": ["White"] * 3}
+        assert _sticker_color(face_colors, "White", 5) == UNKNOWN_COLOR
+
+
+# --- SVG rendering ---
+
+
+class TestRenderCubeSvg:
+    def test_returns_svg_string(self):
+        svg = render_cube_svg()
+        assert svg.startswith("<svg")
+        assert svg.endswith("</svg>")
+        assert 'xmlns="http://www.w3.org/2000/svg"' in svg
+
+    def test_contains_background(self):
+        svg = render_cube_svg()
+        assert BACKGROUND_COLOR in svg
+
+    def test_contains_27_polygons(self):
+        """3 faces × 9 stickers = 27 polygons."""
+        svg = render_cube_svg()
+        assert svg.count("<polygon") == 27
+
+    def test_grey_cube_when_no_colors(self):
+        svg = render_cube_svg()
+        assert UNKNOWN_COLOR in svg
+
+    def test_colored_cube(self):
+        face_colors = {
+            "White": ["White"] * 9,
+            "Blue": ["Blue"] * 9,
+            "Red": ["Red"] * 9,
+        }
+        svg = render_cube_svg(face_colors)
+        assert COLOR_RGB["White"] in svg
+        assert COLOR_RGB["Blue"] in svg
+        assert COLOR_RGB["Red"] in svg
+
+    def test_custom_faces(self):
+        face_colors = {
+            "Yellow": ["Yellow"] * 9,
+            "Green": ["Green"] * 9,
+            "Orange": ["Orange"] * 9,
+        }
+        svg = render_cube_svg(
+            face_colors, top_face="Yellow", right_face="Orange", left_face="Green"
+        )
+        assert COLOR_RGB["Yellow"] in svg
+        assert COLOR_RGB["Green"] in svg
+        assert COLOR_RGB["Orange"] in svg
+
+    def test_viewbox_dimensions(self):
+        svg = render_cube_svg()
+        assert 'viewBox="0 0' in svg


### PR DESCRIPTION
## Summary

Complete rewrite of the GoCube Home Assistant integration:

- **BLE library rewrite** — Clean protocol parser with zero HA imports, proper message framing for all GoCube message types (rotation, state, battery, orientation, stats, cube type)
- **Sleepy device pattern** — Yale BLE lock-style advertisement-triggered connections; entities stay available with cached state when cube sleeps
- **LED brightness control** — Light entity with 6 discrete brightness levels (0x45-0x4B) discovered via BLE reverse engineering, plus Flash/Animation effects
- **Isometric cube visualization** — Live SVG rendering of 3 visible cube faces as an image entity
- **State fingerprint & pattern matching** — 54-character state representation enabling automation triggers on arbitrary cube positions; built-in patterns (Solved, Checkerboard) + user-saveable patterns via HA services with persistent storage
- **New entities** — Rotation event, auto-reconnect switch, reboot button, list patterns button, pattern sensor
- **Test suite** — 61 tests covering protocol parser, data models, and renderer; runs on macOS without HA or BLE hardware

### Breaking changes
- All entity IDs change due to new entity structure
- `bleak-retry-connector` dependency removed
- Connection API completely rewritten

Closes #11

## Test plan
- [ ] Add integration, verify cube connects on advertisement
- [ ] Check all sensors populate (battery, connection state, solved faces, cube type, pattern, fingerprint)
- [ ] Verify face binary sensors show "Face: Blue" etc. format and are not diagnostic
- [ ] Toggle light on/off, adjust brightness slider
- [ ] Trigger Flash/Animation effects
- [ ] Rotate cube and verify rotation events fire
- [ ] Check isometric cube view updates with face colors
- [ ] Save a custom pattern, verify it appears in pattern sensor
- [ ] Press "List Patterns" button, verify persistent notification
- [ ] Disconnect cube, verify assumed_state behavior
- [ ] Re-enable cube, verify auto-reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)